### PR TITLE
feat(store): add Zustand stores with tauri-plugin-store persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,15 @@ dist-ssr
 .claude/*
 !.claude/skills/
 .claude/skills/*
+.claude/skills/code-reviewer
+.claude/skills/code-simplifier
+.claude/skills/find-skills
+
 !.claude/skills/project/
 !.claude/skills/project-*/
+.agent
+.agent/skills/*
+.agents/
 **/openspec
 **/.obsidian
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@tanstack/react-router": "^1.168.1",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-store": "^2.4.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.3
+      '@tauri-apps/plugin-store':
+        specifier: ^2.4.2
+        version: 2.4.2
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1884,6 +1887,9 @@ packages:
 
   '@tauri-apps/plugin-opener@2.5.3':
     resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
+
+  '@tauri-apps/plugin-store@2.4.2':
+    resolution: {integrity: sha512-0ClHS50Oq9HEvLPhNzTNFxbWVOqoAp3dRvtewQBeqfIQ0z5m3JRnOISIn2ZVPCrQC0MyGyhTS9DWhHjpigQE7A==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -4680,6 +4686,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.9.6
 
   '@tauri-apps/plugin-opener@2.5.3':
+    dependencies:
+      '@tauri-apps/api': 2.9.1
+
+  '@tauri-apps/plugin-store@2.4.2':
     dependencies:
       '@tauri-apps/api': 2.9.1
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "skills": {
+    "code-reviewer": {
+      "source": "google-gemini/gemini-cli",
+      "sourceType": "github",
+      "computedHash": "270f0dd1d4c15a798bad5253a309cdc2056fe5322f99ba06ca22ce50581adc02"
+    },
+    "code-simplifier": {
+      "source": "getsentry/skills",
+      "sourceType": "github",
+      "computedHash": "ff9cb10181e31daf1f1644754c491601a7849dff4b4536a1d0ec4f97f680348e"
+    },
+    "find-skills": {
+      "source": "vercel-labs/skills",
+      "sourceType": "github",
+      "computedHash": "d31e234f0c90694a670222cdd1dafa853e051d7066beda389f1097c22dadd461"
+    }
+  }
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6651,6 +6651,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tauri-plugin-store",
  "thiserror 2.0.18",
  "tokio",
  "uuid",
@@ -6963,6 +6964,22 @@ dependencies = [
  "url",
  "windows 0.61.3",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-store"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca1a8ff83c269b115e98726ffc13f9e548a10161544a92ad121d6d0a96e16ea"
+dependencies = [
+ "dunce",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,4 +39,5 @@ entity = { path = "entity" }
 migration = { path = "migration" }
 uuid = { version = "1", features = ["v7"] }
 tokio = { version = "1", features = ["sync"] }
+tauri-plugin-store = "2.4.2"
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "store:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ fn greet(name: &str) -> String {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_store::Builder::new().build())
         .invoke_handler(tauri::generate_handler![
             greet,
             identity::commands::get_device_info,

--- a/src/commands/document.ts
+++ b/src/commands/document.ts
@@ -1,0 +1,35 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface DocumentModel {
+  id: string;
+  workspace_id: string;
+  folder_id: string | null;
+  title: string;
+  rel_path: string;
+  file_hash: number[] | null;
+  yjs_state: number[] | null;
+  state_vector: number[] | null;
+  created_by: string;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface UpsertDocumentInput {
+  id?: string;
+  workspace_id: string;
+  folder_id?: string | null;
+  title: string;
+  rel_path: string;
+}
+
+export async function getDocuments(workspaceId: string): Promise<DocumentModel[]> {
+  return invoke<DocumentModel[]>("db_get_documents", { workspaceId });
+}
+
+export async function upsertDocument(input: UpsertDocumentInput): Promise<DocumentModel> {
+  return invoke<DocumentModel>("db_upsert_document", { input });
+}
+
+export async function deleteDocument(id: string): Promise<void> {
+  return invoke("db_delete_document", { id });
+}

--- a/src/commands/folder.ts
+++ b/src/commands/folder.ts
@@ -1,0 +1,31 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface FolderModel {
+  id: string;
+  workspace_id: string;
+  parent_folder_id: string | null;
+  name: string;
+  rel_path: string;
+  created_by: string;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface CreateFolderInput {
+  workspace_id: string;
+  parent_folder_id?: string | null;
+  name: string;
+  rel_path: string;
+}
+
+export async function getFolders(workspaceId: string): Promise<FolderModel[]> {
+  return invoke<FolderModel[]>("db_get_folders", { workspaceId });
+}
+
+export async function createFolder(input: CreateFolderInput): Promise<FolderModel> {
+  return invoke<FolderModel>("db_create_folder", { input });
+}
+
+export async function deleteFolder(id: string): Promise<void> {
+  return invoke("db_delete_folder", { id });
+}

--- a/src/commands/workspace.ts
+++ b/src/commands/workspace.ts
@@ -1,0 +1,18 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface WorkspaceModel {
+  id: string;
+  name: string;
+  created_by: string;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface InitWorkspaceInput {
+  path: string;
+  name: string;
+}
+
+export async function initWorkspace(input: InitWorkspaceInput): Promise<WorkspaceModel> {
+  return invoke<WorkspaceModel>("db_init_workspace", { input });
+}

--- a/src/lib/tauriStore.ts
+++ b/src/lib/tauriStore.ts
@@ -1,0 +1,48 @@
+import { LazyStore } from "@tauri-apps/plugin-store";
+import { createJSONStorage } from "zustand/middleware";
+
+const storeCache = new Map<string, LazyStore>();
+
+function getOrCreateStore(filename: string): LazyStore {
+  let store = storeCache.get(filename);
+  if (!store) {
+    store = new LazyStore(filename);
+    storeCache.set(filename, store);
+  }
+  return store;
+}
+
+export function createTauriStorage(filename: string) {
+  const store = getOrCreateStore(filename);
+
+  return createJSONStorage(() => ({
+    getItem: async (key: string) => {
+      const value = await store.get<string>(key);
+      return value ?? null;
+    },
+    setItem: async (key: string, value: string) => {
+      await store.set(key, value);
+      await store.save();
+    },
+    removeItem: async (key: string) => {
+      await store.delete(key);
+      await store.save();
+    },
+  }));
+}
+
+/**
+ * Generic hydration guard for any Zustand persist store.
+ * Resolves when the store has finished loading from persistent storage.
+ */
+export function waitForHydration(store: {
+  persist: { hasHydrated: () => boolean; onFinishHydration: (cb: () => void) => void };
+}): Promise<void> {
+  return new Promise((resolve) => {
+    if (store.persist.hasHydrated()) {
+      resolve();
+    } else {
+      store.persist.onFinishHydration(() => resolve());
+    }
+  });
+}

--- a/src/stores/editorStore.ts
+++ b/src/stores/editorStore.ts
@@ -1,0 +1,57 @@
+import { create } from "zustand";
+import { upsertDocument } from "@/commands/document";
+
+interface EditorState {
+  currentDocId: string | null;
+  title: string;
+  relPath: string;
+  content: string;
+  isDirty: boolean;
+  lastSavedAt: Date | null;
+  charCount: number;
+}
+
+interface EditorActions {
+  loadDocument: (id: string, title: string, relPath: string) => void;
+  saveDocument: (workspaceId: string) => Promise<void>;
+  updateContent: (content: string) => void;
+  updateTitle: (title: string) => void;
+  clear: () => void;
+}
+
+const initialState: EditorState = {
+  currentDocId: null,
+  title: "",
+  relPath: "",
+  content: "",
+  isDirty: false,
+  lastSavedAt: null,
+  charCount: 0,
+};
+
+export const useEditorStore = create<EditorState & EditorActions>()((set, get) => ({
+  ...initialState,
+
+  loadDocument: (id, title, relPath) => {
+    set({ ...initialState, currentDocId: id, title, relPath });
+  },
+
+  saveDocument: async (workspaceId) => {
+    const { currentDocId, title, relPath } = get();
+    if (!currentDocId) return;
+
+    await upsertDocument({
+      id: currentDocId,
+      workspace_id: workspaceId,
+      title,
+      rel_path: relPath,
+    });
+    set({ isDirty: false, lastSavedAt: new Date() });
+  },
+
+  updateContent: (content) => set({ content, isDirty: true, charCount: content.length }),
+
+  updateTitle: (title) => set({ title, isDirty: true }),
+
+  clear: () => set(initialState),
+}));

--- a/src/stores/fileTreeStore.ts
+++ b/src/stores/fileTreeStore.ts
@@ -1,0 +1,107 @@
+import { create } from "zustand";
+import {
+  type DocumentModel,
+  deleteDocument as deleteDocumentCmd,
+  getDocuments,
+  type UpsertDocumentInput,
+  upsertDocument,
+} from "@/commands/document";
+import {
+  type CreateFolderInput,
+  createFolder as createFolderCmd,
+  deleteFolder as deleteFolderCmd,
+  type FolderModel,
+  getFolders,
+} from "@/commands/folder";
+
+interface FileTreeState {
+  documents: DocumentModel[];
+  folders: FolderModel[];
+  selectedFile: string | null;
+  expandedFolders: Set<string>;
+  isLoading: boolean;
+}
+
+interface FileTreeActions {
+  loadTree: (workspaceId: string) => Promise<void>;
+  selectFile: (id: string | null) => void;
+  toggleFolder: (folderId: string) => void;
+  createDocument: (input: UpsertDocumentInput) => Promise<DocumentModel>;
+  deleteDocument: (id: string) => Promise<void>;
+  createFolder: (input: CreateFolderInput) => Promise<FolderModel>;
+  deleteFolder: (id: string) => Promise<void>;
+  clear: () => void;
+}
+
+const initialState: FileTreeState = {
+  documents: [],
+  folders: [],
+  selectedFile: null,
+  expandedFolders: new Set<string>(),
+  isLoading: false,
+};
+
+export const useFileTreeStore = create<FileTreeState & FileTreeActions>()((set, get) => ({
+  ...initialState,
+
+  loadTree: async (workspaceId) => {
+    set({ isLoading: true });
+    try {
+      const [docs, dirs] = await Promise.all([getDocuments(workspaceId), getFolders(workspaceId)]);
+      set({ documents: docs, folders: dirs });
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+
+  selectFile: (id) => set({ selectedFile: id }),
+
+  toggleFolder: (folderId) => {
+    const { expandedFolders } = get();
+    const next = new Set(expandedFolders);
+    if (next.has(folderId)) {
+      next.delete(folderId);
+    } else {
+      next.add(folderId);
+    }
+    set({ expandedFolders: next });
+  },
+
+  createDocument: async (input) => {
+    const doc = await upsertDocument(input);
+    set((s) => ({
+      documents: input.id
+        ? s.documents.map((d) => (d.id === doc.id ? doc : d))
+        : [...s.documents, doc],
+    }));
+    return doc;
+  },
+
+  deleteDocument: async (id) => {
+    await deleteDocumentCmd(id);
+    set((s) => ({
+      documents: s.documents.filter((d) => d.id !== id),
+      selectedFile: s.selectedFile === id ? null : s.selectedFile,
+    }));
+  },
+
+  createFolder: async (input) => {
+    const folder = await createFolderCmd(input);
+    set((s) => ({ folders: [...s.folders, folder] }));
+    return folder;
+  },
+
+  deleteFolder: async (id) => {
+    await deleteFolderCmd(id);
+    set((s) => ({
+      folders: s.folders.filter((f) => f.id !== id),
+      documents: s.documents.filter((d) => d.folder_id !== id),
+      selectedFile:
+        s.selectedFile && s.documents.some((d) => d.folder_id === id && d.id === s.selectedFile)
+          ? null
+          : s.selectedFile,
+    }));
+  },
+
+  clear: () => set(initialState),
+}));

--- a/src/stores/onboardingStore.ts
+++ b/src/stores/onboardingStore.ts
@@ -1,0 +1,41 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { createTauriStorage, waitForHydration } from "@/lib/tauriStore";
+
+interface OnboardingState {
+  isCompleted: boolean;
+  currentStep: number;
+}
+
+interface OnboardingActions {
+  nextStep: () => void;
+  prevStep: () => void;
+  complete: () => void;
+  reset: () => void;
+}
+
+export const useOnboardingStore = create<OnboardingState & OnboardingActions>()(
+  persist(
+    (set) => ({
+      isCompleted: false,
+      currentStep: 0,
+
+      nextStep: () => set((s) => ({ currentStep: s.currentStep + 1 })),
+
+      prevStep: () => set((s) => ({ currentStep: Math.max(0, s.currentStep - 1) })),
+
+      complete: () => set({ isCompleted: true }),
+
+      reset: () => set({ isCompleted: false, currentStep: 0 }),
+    }),
+    {
+      name: "swarmnote-onboarding",
+      storage: createTauriStorage("settings.json"),
+      partialize: (state) => ({
+        isCompleted: state.isCompleted,
+      }),
+    },
+  ),
+);
+
+export const waitForOnboardingHydration = () => waitForHydration(useOnboardingStore);

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { activateLocale, detectLocale, type Locale } from "@/i18n";
+import { createTauriStorage, waitForHydration } from "@/lib/tauriStore";
 
 type Theme = "light" | "dark" | "system";
 
@@ -9,6 +10,9 @@ interface UIState {
   theme: Theme;
   resolvedTheme: "light" | "dark";
   locale: Locale;
+}
+
+interface UIActions {
   toggleSidebar: () => void;
   setSidebarOpen: (open: boolean) => void;
   setTheme: (theme: Theme) => void;
@@ -23,7 +27,7 @@ function applyTheme(resolved: "light" | "dark") {
   document.documentElement.classList.toggle("dark", resolved === "dark");
 }
 
-export const useUIStore = create<UIState>()(
+export const useUIStore = create<UIState & UIActions>()(
   persist(
     (set) => ({
       sidebarOpen: true,
@@ -50,6 +54,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "swarmnote-ui",
+      storage: createTauriStorage("settings.json"),
       partialize: (state) => ({
         sidebarOpen: state.sidebarOpen,
         theme: state.theme,
@@ -67,12 +72,12 @@ export const useUIStore = create<UIState>()(
   ),
 );
 
+export const waitForUiHydration = () => waitForHydration(useUIStore);
+
 // Listen to system theme changes when in "system" mode
-if (typeof window !== "undefined") {
-  window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
-    const { theme, setTheme } = useUIStore.getState();
-    if (theme === "system") {
-      setTheme("system");
-    }
-  });
-}
+window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
+  const { theme, setTheme } = useUIStore.getState();
+  if (theme === "system") {
+    setTheme("system");
+  }
+});

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+import { initWorkspace, type WorkspaceModel } from "@/commands/workspace";
+
+interface WorkspaceState {
+  workspace: WorkspaceModel | null;
+  isLoading: boolean;
+}
+
+interface WorkspaceActions {
+  openWorkspace: (path: string, name: string) => Promise<void>;
+  clearWorkspace: () => void;
+}
+
+export const useWorkspaceStore = create<WorkspaceState & WorkspaceActions>()((set) => ({
+  workspace: null,
+  isLoading: false,
+
+  openWorkspace: async (path, name) => {
+    set({ isLoading: true });
+    try {
+      const workspace = await initWorkspace({ path, name });
+      set({ workspace });
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+
+  clearWorkspace: () => set({ workspace: null }),
+}));


### PR DESCRIPTION
## Summary
- Integrate `tauri-plugin-store` (Rust + JS) for native persistent storage
- Create `tauriStore` adapter bridging Zustand `persist` middleware with Tauri store API
- Add core Zustand stores: `workspaceStore`, `editorStore`, `fileTreeStore`, `onboardingStore`
- Add Tauri command wrappers: `document.ts`, `folder.ts`, `workspace.ts`
- Migrate `uiStore` to use Tauri storage with State/Actions interface separation
- Update `.gitignore` for agent directories

## Test plan
- [ ] Verify `pnpm tauri dev` starts without errors
- [ ] Confirm UI settings (theme, sidebar, locale) persist across app restarts
- [ ] Confirm onboarding completion state persists across restarts
- [ ] Verify workspace/document/folder CRUD operations work via stores