### PR TITLE
feat(filetree): filesystem-driven file tree with CRUD and live watching

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lucide-react": "^0.577.0",
     "radix-ui": "^1.4.3",
     "react": "^19.1.0",
+    "react-arborist": "^3.4.3",
     "react-dom": "^19.1.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       react:
         specifier: ^19.1.0
         version: 19.2.4
+      react-arborist:
+        specifier: ^3.4.3
+        version: 3.4.3(@types/node@25.5.0)(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-dom:
         specifier: ^19.1.0
         version: 19.2.4(react@19.2.4)
@@ -1469,6 +1472,15 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@react-dnd/asap@4.0.1':
+    resolution: {integrity: sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==}
+
+  '@react-dnd/invariant@2.0.0':
+    resolution: {integrity: sha512-xL4RCQBCBDJ+GRwKTFhGUW8GXa4yoDfJrPbLblc3U09ciS+9ZJXJ3Qrcs/x2IODOdIE5kQxvMmE2UKyqUictUw==}
+
+  '@react-dnd/shallowequal@2.0.0':
+    resolution: {integrity: sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==}
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -2175,6 +2187,9 @@ packages:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
 
+  dnd-core@14.0.1:
+    resolution: {integrity: sha512-+PVS2VPTgKFPYWo3vAFEA8WPbTf7/xo43TifH9G8S1KqnrQu0o77A3unrF5yOugy4mIz7K5wAVFHUcha7wsz6A==}
+
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
@@ -2292,6 +2307,9 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -2574,6 +2592,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  memoize-one@5.2.1:
+    resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
+
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
@@ -2697,10 +2718,37 @@ packages:
       '@types/react-dom':
         optional: true
 
+  react-arborist@3.4.3:
+    resolution: {integrity: sha512-yFnq1nIQhT2uJY4TZVz2tgAiBb9lxSyvF4vC3S8POCK8xLzjGIxVv3/4dmYquQJ7AHxaZZArRGHiHKsEewKdTQ==}
+    peerDependencies:
+      react: '>= 16.14'
+      react-dom: '>= 16.14'
+
+  react-dnd-html5-backend@14.1.0:
+    resolution: {integrity: sha512-6ONeqEC3XKVf4eVmMTe0oPds+c5B9Foyj8p/ZKLb7kL2qh9COYxiBHv3szd6gztqi/efkmriywLUVlPotqoJyw==}
+
+  react-dnd@14.0.5:
+    resolution: {integrity: sha512-9i1jSgbyVw0ELlEVt/NkCUkxy1hmhJOkePoCH713u75vzHGyXhPDm28oLfc2NMSBjZRM1Y+wRjHXJT3sPrTy+A==}
+    peerDependencies:
+      '@types/hoist-non-react-statics': '>= 3.3.1'
+      '@types/node': '>= 12'
+      '@types/react': '>= 16'
+      react: '>= 16.14'
+    peerDependenciesMeta:
+      '@types/hoist-non-react-statics':
+        optional: true
+      '@types/node':
+        optional: true
+      '@types/react':
+        optional: true
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -2739,6 +2787,13 @@ packages:
       '@types/react':
         optional: true
 
+  react-window@1.8.11:
+    resolution: {integrity: sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==}
+    engines: {node: '>8.0.0'}
+    peerDependencies:
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -2758,6 +2813,12 @@ packages:
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
+
+  redux@4.2.1:
+    resolution: {integrity: sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==}
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -4375,6 +4436,12 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-dnd/asap@4.0.1': {}
+
+  '@react-dnd/invariant@2.0.0': {}
+
+  '@react-dnd/shallowequal@2.0.0': {}
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.57.0':
@@ -4998,6 +5065,12 @@ snapshots:
 
   diff@8.0.3: {}
 
+  dnd-core@14.0.1:
+    dependencies:
+      '@react-dnd/asap': 4.0.1
+      '@react-dnd/invariant': 2.0.0
+      redux: 4.2.1
+
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
@@ -5144,6 +5217,10 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
+
+  hoist-non-react-statics@3.3.2:
+    dependencies:
+      react-is: 16.13.1
 
   ieee754@1.2.1: {}
 
@@ -5348,6 +5425,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  memoize-one@5.2.1: {}
+
   meow@13.2.0: {}
 
   micromatch@4.0.8:
@@ -5506,10 +5585,42 @@ snapshots:
       '@types/react': 19.2.10
       '@types/react-dom': 19.2.3(@types/react@19.2.10)
 
+  react-arborist@3.4.3(@types/node@25.5.0)(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dnd: 14.0.5(@types/node@25.5.0)(@types/react@19.2.10)(react@19.2.4)
+      react-dnd-html5-backend: 14.1.0
+      react-dom: 19.2.4(react@19.2.4)
+      react-window: 1.8.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      redux: 5.0.1
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/hoist-non-react-statics'
+      - '@types/node'
+      - '@types/react'
+
+  react-dnd-html5-backend@14.1.0:
+    dependencies:
+      dnd-core: 14.0.1
+
+  react-dnd@14.0.5(@types/node@25.5.0)(@types/react@19.2.10)(react@19.2.4):
+    dependencies:
+      '@react-dnd/invariant': 2.0.0
+      '@react-dnd/shallowequal': 2.0.0
+      dnd-core: 14.0.1
+      fast-deep-equal: 3.1.3
+      hoist-non-react-statics: 3.3.2
+      react: 19.2.4
+    optionalDependencies:
+      '@types/node': 25.5.0
+      '@types/react': 19.2.10
+
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-is@16.13.1: {}
 
   react-is@18.3.1: {}
 
@@ -5542,6 +5653,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.10
 
+  react-window@1.8.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      memoize-one: 5.2.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   react@19.2.4: {}
 
   readable-stream@3.6.2:
@@ -5565,6 +5683,12 @@ snapshots:
       source-map: 0.6.1
       tiny-invariant: 1.3.3
       tslib: 2.8.1
+
+  redux@4.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+
+  redux@5.0.1: {}
 
   require-directory@2.1.1: {}
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1929,6 +1929,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2942,6 +2951,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3119,6 +3148,26 @@ dependencies = [
  "security-framework 3.7.0",
  "windows-sys 0.60.2",
  "zeroize",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -3929,6 +3978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -4156,6 +4206,45 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a689eb4262184d9a1727f9087cd03883ea716682ab03ed24efec57d7716dccb8"
+dependencies = [
+ "log",
+ "notify",
+ "notify-types",
+ "tempfile",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -6670,6 +6759,8 @@ dependencies = [
  "keyring",
  "log",
  "migration",
+ "notify",
+ "notify-debouncer-mini",
  "sea-orm",
  "serde",
  "serde_json",
@@ -6679,6 +6770,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-store",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "uuid",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,4 +41,9 @@ uuid = { version = "1", features = ["v7"] }
 tokio = { version = "1", features = ["sync"] }
 tauri-plugin-store = "2.4.2"
 tauri-plugin-dialog = "2.6.0"
+notify = { version = "8", features = [] }
+notify-debouncer-mini = "0.6"
+
+[dev-dependencies]
+tempfile = "3"
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -15,6 +15,9 @@
     "core:window:allow-close",
     "opener:default",
     "store:default",
-    "dialog:default"
+    "dialog:default",
+    "core:event:default",
+    "core:event:allow-listen",
+    "core:event:allow-emit"
   ]
 }

--- a/src-tauri/src/db/commands/workspace.rs
+++ b/src-tauri/src/db/commands/workspace.rs
@@ -56,6 +56,8 @@ pub async fn open_workspace(
     identity: State<'_, IdentityState>,
     config_state: State<'_, GlobalConfigState>,
     ws_state: State<'_, WorkspaceState>,
+    watcher_state: State<'_, crate::fs::watcher::FsWatcherState>,
+    app_handle: tauri::AppHandle,
 ) -> AppResult<WorkspaceInfo> {
     let ws_path = PathBuf::from(&path);
 
@@ -109,6 +111,11 @@ pub async fn open_workspace(
         {
             log::warn!("Failed to update global config: {e}");
         }
+    }
+
+    // Start file system watcher for the new workspace
+    if let Err(e) = crate::fs::watcher::start_watching(&app_handle, &ws_path, &watcher_state) {
+        log::warn!("Failed to start fs watcher: {e}");
     }
 
     Ok(info)

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -18,6 +18,12 @@ pub enum AppError {
     FolderNotEmpty(String),
     #[error("Invalid path: {0}")]
     InvalidPath(String),
+    #[error("Path traversal detected: {0}")]
+    PathTraversal(String),
+    #[error("Name conflict: {0}")]
+    NameConflict(String),
+    #[error("No workspace open")]
+    NoWorkspaceOpen,
 }
 
 /// Structured serialization: `{ kind: "...", message: "..." }` for frontend.
@@ -36,6 +42,9 @@ impl Serialize for AppError {
             AppError::NoAppDataDir => ("NoAppDataDir", self.to_string()),
             AppError::FolderNotEmpty(msg) => ("FolderNotEmpty", msg.clone()),
             AppError::InvalidPath(msg) => ("InvalidPath", msg.clone()),
+            AppError::PathTraversal(msg) => ("PathTraversal", msg.clone()),
+            AppError::NameConflict(msg) => ("NameConflict", msg.clone()),
+            AppError::NoWorkspaceOpen => ("NoWorkspaceOpen", self.to_string()),
         };
 
         state.serialize_field("kind", kind)?;

--- a/src-tauri/src/fs/commands.rs
+++ b/src-tauri/src/fs/commands.rs
@@ -1,0 +1,90 @@
+use tauri::State;
+
+use crate::db::state::WorkspaceState;
+use crate::error::{AppError, AppResult};
+
+use super::FileTreeNode;
+
+/// Get the workspace path from state, or error.
+async fn workspace_path(ws_state: &WorkspaceState) -> Result<String, AppError> {
+    ws_state
+        .0
+        .read()
+        .await
+        .as_ref()
+        .map(|ws| ws.path.clone())
+        .ok_or(AppError::NoWorkspaceOpen)
+}
+
+#[tauri::command]
+pub async fn scan_workspace_tree(
+    ws_state: State<'_, WorkspaceState>,
+) -> AppResult<Vec<FileTreeNode>> {
+    let path = workspace_path(&ws_state).await?;
+    let ws_path = std::path::PathBuf::from(&path);
+
+    // Run blocking FS scan on a background thread
+    tokio::task::spawn_blocking(move || super::scan::scan_workspace_tree(&ws_path))
+        .await
+        .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))?
+}
+
+#[tauri::command]
+pub async fn fs_create_file(
+    parent_rel: String,
+    name: String,
+    ws_state: State<'_, WorkspaceState>,
+) -> AppResult<String> {
+    let path = workspace_path(&ws_state).await?;
+    let ws_path = std::path::PathBuf::from(&path);
+    tokio::task::spawn_blocking(move || super::crud::create_file(&ws_path, &parent_rel, &name))
+        .await
+        .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))?
+}
+
+#[tauri::command]
+pub async fn fs_create_dir(
+    parent_rel: String,
+    name: String,
+    ws_state: State<'_, WorkspaceState>,
+) -> AppResult<String> {
+    let path = workspace_path(&ws_state).await?;
+    let ws_path = std::path::PathBuf::from(&path);
+    tokio::task::spawn_blocking(move || super::crud::create_dir(&ws_path, &parent_rel, &name))
+        .await
+        .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))?
+}
+
+#[tauri::command]
+pub async fn fs_delete_file(
+    rel_path: String,
+    ws_state: State<'_, WorkspaceState>,
+) -> AppResult<()> {
+    let path = workspace_path(&ws_state).await?;
+    let ws_path = std::path::PathBuf::from(&path);
+    tokio::task::spawn_blocking(move || super::crud::delete_file(&ws_path, &rel_path))
+        .await
+        .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))?
+}
+
+#[tauri::command]
+pub async fn fs_delete_dir(rel_path: String, ws_state: State<'_, WorkspaceState>) -> AppResult<()> {
+    let path = workspace_path(&ws_state).await?;
+    let ws_path = std::path::PathBuf::from(&path);
+    tokio::task::spawn_blocking(move || super::crud::delete_dir(&ws_path, &rel_path))
+        .await
+        .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))?
+}
+
+#[tauri::command]
+pub async fn fs_rename(
+    rel_path: String,
+    new_name: String,
+    ws_state: State<'_, WorkspaceState>,
+) -> AppResult<String> {
+    let path = workspace_path(&ws_state).await?;
+    let ws_path = std::path::PathBuf::from(&path);
+    tokio::task::spawn_blocking(move || super::crud::rename(&ws_path, &rel_path, &new_name))
+        .await
+        .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))?
+}

--- a/src-tauri/src/fs/crud.rs
+++ b/src-tauri/src/fs/crud.rs
@@ -1,0 +1,277 @@
+use std::path::{Path, PathBuf};
+
+use crate::error::AppError;
+
+/// Validate that `rel_path` does not escape the workspace root.
+///
+/// Rejects paths containing `..` components or absolute paths.
+pub fn validate_rel_path(workspace: &Path, rel_path: &str) -> Result<PathBuf, AppError> {
+    if rel_path.contains("..") {
+        return Err(AppError::PathTraversal(rel_path.to_owned()));
+    }
+
+    let full = workspace.join(rel_path);
+    let canonical_ws = workspace
+        .canonicalize()
+        .map_err(|e| AppError::InvalidPath(format!("{}: {e}", workspace.display())))?;
+
+    // For new paths that don't exist yet, canonicalize the parent
+    let check_path = if full.exists() {
+        full.canonicalize()
+            .map_err(|e| AppError::InvalidPath(e.to_string()))?
+    } else if let Some(parent) = full.parent() {
+        let canonical_parent = parent
+            .canonicalize()
+            .map_err(|e| AppError::InvalidPath(e.to_string()))?;
+        canonical_parent.join(full.file_name().unwrap_or_default())
+    } else {
+        return Err(AppError::PathTraversal(rel_path.to_owned()));
+    };
+
+    if !check_path.starts_with(&canonical_ws) {
+        return Err(AppError::PathTraversal(rel_path.to_owned()));
+    }
+
+    Ok(full)
+}
+
+/// Find a non-conflicting name by appending ` 1`, ` 2`, etc.
+fn resolve_conflict(dir: &Path, base_name: &str, extension: &str) -> String {
+    let mut counter = 1u32;
+    loop {
+        let candidate = if extension.is_empty() {
+            format!("{base_name} {counter}")
+        } else {
+            format!("{base_name} {counter}.{extension}")
+        };
+        if !dir.join(&candidate).exists() {
+            return candidate;
+        }
+        counter += 1;
+    }
+}
+
+/// Create a new `.md` file. Returns the rel_path of the created file.
+///
+/// If a file with the same name exists, auto-numbers (e.g. `name 1.md`).
+pub fn create_file(workspace: &Path, parent_rel: &str, name: &str) -> Result<String, AppError> {
+    let parent = if parent_rel.is_empty() {
+        workspace.to_path_buf()
+    } else {
+        validate_rel_path(workspace, parent_rel)?
+    };
+
+    let filename = format!("{name}.md");
+    let full_path = parent.join(&filename);
+
+    let actual_name = if full_path.exists() {
+        resolve_conflict(&parent, name, "md")
+    } else {
+        filename
+    };
+
+    std::fs::write(parent.join(&actual_name), "")?;
+
+    let rel = parent
+        .join(&actual_name)
+        .strip_prefix(workspace)
+        .unwrap_or(Path::new(&actual_name))
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    Ok(rel)
+}
+
+/// Create a new directory. Returns the rel_path of the created directory.
+pub fn create_dir(workspace: &Path, parent_rel: &str, name: &str) -> Result<String, AppError> {
+    let parent = if parent_rel.is_empty() {
+        workspace.to_path_buf()
+    } else {
+        validate_rel_path(workspace, parent_rel)?
+    };
+
+    let full_path = parent.join(name);
+
+    let actual_name = if full_path.exists() {
+        resolve_conflict(&parent, name, "")
+    } else {
+        name.to_owned()
+    };
+
+    std::fs::create_dir_all(parent.join(&actual_name))?;
+
+    let rel = parent
+        .join(&actual_name)
+        .strip_prefix(workspace)
+        .unwrap_or(Path::new(&actual_name))
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    Ok(rel)
+}
+
+/// Delete a file. Idempotent — succeeds if the file doesn't exist.
+pub fn delete_file(workspace: &Path, rel_path: &str) -> Result<(), AppError> {
+    let full = validate_rel_path(workspace, rel_path)?;
+    match std::fs::remove_file(full) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Recursively delete a directory and all its contents.
+pub fn delete_dir(workspace: &Path, rel_path: &str) -> Result<(), AppError> {
+    let full = validate_rel_path(workspace, rel_path)?;
+    match std::fs::remove_dir_all(full) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Rename a file or directory. Returns the new rel_path.
+pub fn rename(workspace: &Path, rel_path: &str, new_name: &str) -> Result<String, AppError> {
+    let full = validate_rel_path(workspace, rel_path)?;
+    let parent = full
+        .parent()
+        .ok_or_else(|| AppError::InvalidPath("no parent directory".into()))?;
+
+    // For files, preserve extension if new_name doesn't have one
+    let target_name = if full.is_file() && !new_name.contains('.') {
+        let ext = full.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if ext.is_empty() {
+            new_name.to_owned()
+        } else {
+            format!("{new_name}.{ext}")
+        }
+    } else {
+        new_name.to_owned()
+    };
+
+    let new_path = parent.join(&target_name);
+    if new_path.exists() {
+        return Err(AppError::NameConflict(target_name));
+    }
+
+    std::fs::rename(&full, &new_path)?;
+
+    let rel = new_path
+        .strip_prefix(workspace)
+        .unwrap_or(&new_path)
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    Ok(rel)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn tmp() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    #[test]
+    fn create_file_basic() {
+        let dir = tmp();
+        let rel = create_file(dir.path(), "", "test").unwrap();
+        assert_eq!(rel, "test.md");
+        assert!(dir.path().join("test.md").exists());
+    }
+
+    #[test]
+    fn create_file_in_subdir() {
+        let dir = tmp();
+        fs::create_dir(dir.path().join("notes")).unwrap();
+        let rel = create_file(dir.path(), "notes", "diary").unwrap();
+        assert_eq!(rel, "notes/diary.md");
+    }
+
+    #[test]
+    fn create_file_conflict_auto_numbers() {
+        let dir = tmp();
+        fs::write(dir.path().join("note.md"), "").unwrap();
+        let rel = create_file(dir.path(), "", "note").unwrap();
+        assert_eq!(rel, "note 1.md");
+        assert!(dir.path().join("note 1.md").exists());
+    }
+
+    #[test]
+    fn create_dir_basic() {
+        let dir = tmp();
+        let rel = create_dir(dir.path(), "", "folder").unwrap();
+        assert_eq!(rel, "folder");
+        assert!(dir.path().join("folder").is_dir());
+    }
+
+    #[test]
+    fn create_dir_conflict_auto_numbers() {
+        let dir = tmp();
+        fs::create_dir(dir.path().join("folder")).unwrap();
+        let rel = create_dir(dir.path(), "", "folder").unwrap();
+        assert_eq!(rel, "folder 1");
+    }
+
+    #[test]
+    fn delete_file_idempotent() {
+        let dir = tmp();
+        // Should not error on non-existent file
+        delete_file(dir.path(), "nonexistent.md").unwrap();
+    }
+
+    #[test]
+    fn delete_file_existing() {
+        let dir = tmp();
+        fs::write(dir.path().join("del.md"), "content").unwrap();
+        delete_file(dir.path(), "del.md").unwrap();
+        assert!(!dir.path().join("del.md").exists());
+    }
+
+    #[test]
+    fn delete_dir_recursive() {
+        let dir = tmp();
+        let sub = dir.path().join("folder");
+        fs::create_dir(&sub).unwrap();
+        fs::write(sub.join("file.md"), "").unwrap();
+        delete_dir(dir.path(), "folder").unwrap();
+        assert!(!sub.exists());
+    }
+
+    #[test]
+    fn rename_file_basic() {
+        let dir = tmp();
+        fs::write(dir.path().join("old.md"), "").unwrap();
+        let rel = rename(dir.path(), "old.md", "new").unwrap();
+        assert_eq!(rel, "new.md");
+        assert!(dir.path().join("new.md").exists());
+        assert!(!dir.path().join("old.md").exists());
+    }
+
+    #[test]
+    fn rename_conflict_errors() {
+        let dir = tmp();
+        fs::write(dir.path().join("a.md"), "").unwrap();
+        fs::write(dir.path().join("b.md"), "").unwrap();
+        let err = rename(dir.path(), "a.md", "b").unwrap_err();
+        assert!(matches!(err, AppError::NameConflict(_)));
+    }
+
+    #[test]
+    fn path_traversal_rejected() {
+        let dir = tmp();
+        let err = validate_rel_path(dir.path(), "../etc/passwd").unwrap_err();
+        assert!(matches!(err, AppError::PathTraversal(_)));
+    }
+
+    #[test]
+    fn rename_directory() {
+        let dir = tmp();
+        fs::create_dir(dir.path().join("old-folder")).unwrap();
+        let rel = rename(dir.path(), "old-folder", "new-folder").unwrap();
+        assert_eq!(rel, "new-folder");
+        assert!(dir.path().join("new-folder").is_dir());
+    }
+}

--- a/src-tauri/src/fs/mod.rs
+++ b/src-tauri/src/fs/mod.rs
@@ -1,0 +1,18 @@
+pub mod commands;
+pub mod crud;
+pub mod scan;
+pub mod watcher;
+
+use serde::Serialize;
+
+/// A node in the workspace file tree.
+#[derive(Debug, Clone, Serialize)]
+pub struct FileTreeNode {
+    /// Relative path from workspace root (used as unique ID).
+    pub id: String,
+    /// Display name (filename without `.md` extension for files).
+    pub name: String,
+    /// Present only for directories.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub children: Option<Vec<FileTreeNode>>,
+}

--- a/src-tauri/src/fs/scan.rs
+++ b/src-tauri/src/fs/scan.rs
@@ -1,0 +1,161 @@
+use std::path::Path;
+
+use crate::error::AppError;
+
+use super::FileTreeNode;
+
+/// Recursively scan a workspace directory and build a `FileTreeNode` tree.
+///
+/// Rules:
+/// - Only `.md` files and directories are included.
+/// - Hidden entries (starting with `.`) are excluded.
+/// - Symlinks are skipped (uses `fs::metadata`, not `symlink_metadata`).
+/// - Sorted: directories first, then files, case-insensitive alphabetical.
+pub fn scan_workspace_tree(workspace_path: &Path) -> Result<Vec<FileTreeNode>, AppError> {
+    scan_dir(workspace_path, workspace_path)
+}
+
+fn scan_dir(root: &Path, dir: &Path) -> Result<Vec<FileTreeNode>, AppError> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e.into()),
+    };
+
+    let mut dirs = Vec::new();
+    let mut files = Vec::new();
+
+    for entry in entries {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        // Skip hidden entries
+        if name_str.starts_with('.') {
+            continue;
+        }
+
+        // Use metadata (follows symlinks) — if it fails, the entry is a broken
+        // symlink or inaccessible; skip it.
+        let meta = match std::fs::metadata(entry.path()) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+
+        // Skip symlinks: if symlink_metadata differs from metadata in file_type,
+        // the entry is a symlink. But simpler: just check symlink_metadata directly.
+        if entry.path().read_link().is_ok() {
+            continue;
+        }
+
+        let rel_path = entry
+            .path()
+            .strip_prefix(root)
+            .unwrap_or(entry.path().as_path())
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        if meta.is_dir() {
+            let children = scan_dir(root, &entry.path())?;
+            dirs.push(FileTreeNode {
+                id: rel_path,
+                name: name_str.into_owned(),
+                children: Some(children),
+            });
+        } else if meta.is_file() && name_str.ends_with(".md") {
+            let display_name = name_str.strip_suffix(".md").unwrap_or(&name_str);
+            files.push(FileTreeNode {
+                id: rel_path,
+                name: display_name.to_string(),
+                children: None,
+            });
+        }
+    }
+
+    // Sort: case-insensitive alphabetical
+    dirs.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    files.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+
+    // Directories first, then files
+    dirs.extend(files);
+    Ok(dirs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn setup_temp_dir() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    #[test]
+    fn scan_empty_directory() {
+        let dir = setup_temp_dir();
+        let result = scan_workspace_tree(dir.path()).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn scan_mixed_content() {
+        let dir = setup_temp_dir();
+        fs::write(dir.path().join("hello.md"), "# Hello").unwrap();
+        fs::write(dir.path().join("image.png"), "binary").unwrap();
+        fs::create_dir(dir.path().join("notes")).unwrap();
+        fs::write(dir.path().join("notes").join("sub.md"), "# Sub").unwrap();
+
+        let result = scan_workspace_tree(dir.path()).unwrap();
+
+        // Should have: notes/ folder, hello.md file (no image.png)
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].name, "notes"); // folder first
+        assert!(result[0].children.is_some());
+        assert_eq!(result[0].children.as_ref().unwrap().len(), 1);
+        assert_eq!(result[1].name, "hello"); // file second, no .md suffix
+        assert!(result[1].children.is_none());
+    }
+
+    #[test]
+    fn scan_hidden_files_filtered() {
+        let dir = setup_temp_dir();
+        fs::create_dir(dir.path().join(".swarmnote")).unwrap();
+        fs::create_dir(dir.path().join(".git")).unwrap();
+        fs::write(dir.path().join(".hidden.md"), "secret").unwrap();
+        fs::write(dir.path().join("visible.md"), "public").unwrap();
+
+        let result = scan_workspace_tree(dir.path()).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "visible");
+    }
+
+    #[test]
+    fn scan_sorting_folders_first_case_insensitive() {
+        let dir = setup_temp_dir();
+        fs::write(dir.path().join("zebra.md"), "").unwrap();
+        fs::write(dir.path().join("Alice.md"), "").unwrap();
+        fs::create_dir(dir.path().join("Notes")).unwrap();
+        fs::create_dir(dir.path().join("archive")).unwrap();
+
+        let result = scan_workspace_tree(dir.path()).unwrap();
+
+        // Folders first: archive, Notes; then files: Alice, zebra
+        assert_eq!(result.len(), 4);
+        assert_eq!(result[0].name, "archive");
+        assert_eq!(result[1].name, "Notes");
+        assert_eq!(result[2].name, "Alice");
+        assert_eq!(result[3].name, "zebra");
+    }
+
+    #[test]
+    fn scan_rel_path_uses_forward_slashes() {
+        let dir = setup_temp_dir();
+        fs::create_dir(dir.path().join("sub")).unwrap();
+        fs::write(dir.path().join("sub").join("note.md"), "").unwrap();
+
+        let result = scan_workspace_tree(dir.path()).unwrap();
+        let sub = &result[0];
+        let note = &sub.children.as_ref().unwrap()[0];
+        assert_eq!(note.id, "sub/note.md");
+    }
+}

--- a/src-tauri/src/fs/watcher.rs
+++ b/src-tauri/src/fs/watcher.rs
@@ -1,0 +1,145 @@
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::Duration;
+
+use notify_debouncer_mini::{new_debouncer, DebouncedEventKind, Debouncer};
+use tauri::{AppHandle, Emitter};
+
+type FsNotifyWatcher = notify::RecommendedWatcher;
+
+/// Managed Tauri state holding the active file-system watcher.
+pub struct FsWatcherState(pub Mutex<Option<Debouncer<FsNotifyWatcher>>>);
+
+impl FsWatcherState {
+    pub fn new() -> Self {
+        Self(Mutex::new(None))
+    }
+}
+
+/// Returns `true` if the path should trigger a tree-changed event.
+fn is_relevant_change(path: &Path, workspace: &Path) -> bool {
+    let rel = match path.strip_prefix(workspace) {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+
+    for component in rel.components() {
+        let s = component.as_os_str().to_string_lossy();
+        if s.starts_with('.') {
+            return false;
+        }
+    }
+
+    // Directory changes are always relevant (create/delete folder)
+    if path.is_dir() || !path.exists() {
+        // If the path no longer exists, we can't check is_dir — assume relevant
+        // unless the extension tells us otherwise.
+        let ext = path.extension().and_then(|e| e.to_str());
+        return ext.is_none() || ext == Some("md");
+    }
+
+    // Only .md file changes
+    path.extension().and_then(|e| e.to_str()) == Some("md")
+}
+
+/// Start watching a workspace directory for file changes.
+///
+/// Debounces events by 100ms and emits `fs:tree-changed` to the frontend.
+pub fn start_watching(
+    app_handle: &AppHandle,
+    workspace_path: &Path,
+    state: &FsWatcherState,
+) -> Result<(), crate::error::AppError> {
+    // Stop any existing watcher first
+    stop_watching(state);
+
+    let app = app_handle.clone();
+    let ws_path = workspace_path.to_path_buf();
+
+    let debouncer = new_debouncer(
+        Duration::from_millis(100),
+        move |events: Result<Vec<notify_debouncer_mini::DebouncedEvent>, notify::Error>| {
+            let events = match events {
+                Ok(evts) => evts,
+                Err(e) => {
+                    log::warn!("fs watcher error: {e}");
+                    return;
+                }
+            };
+
+            let any_relevant = events
+                .iter()
+                .filter(|e| e.kind == DebouncedEventKind::Any)
+                .any(|e| is_relevant_change(&e.path, &ws_path));
+
+            if any_relevant {
+                if let Err(e) = app.emit("fs:tree-changed", ()) {
+                    log::warn!("Failed to emit fs:tree-changed: {e}");
+                }
+            }
+        },
+    )
+    .map_err(|e| crate::error::AppError::Io(std::io::Error::other(e.to_string())))?;
+
+    // Watch the workspace directory recursively
+    let watcher_path = PathBuf::from(workspace_path);
+    {
+        let mut guard = state.0.lock().unwrap();
+        *guard = Some(debouncer);
+        if let Some(ref mut d) = *guard {
+            d.watcher()
+                .watch(&watcher_path, notify::RecursiveMode::Recursive)
+                .map_err(|e| crate::error::AppError::Io(std::io::Error::other(e.to_string())))?;
+        }
+    }
+
+    log::info!("Started fs watcher for: {}", workspace_path.display());
+
+    Ok(())
+}
+
+/// Stop the active file-system watcher (if any).
+pub fn stop_watching(state: &FsWatcherState) {
+    let mut guard = state.0.lock().unwrap();
+    if guard.take().is_some() {
+        log::info!("Stopped fs watcher");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn ws() -> PathBuf {
+        PathBuf::from("/workspace")
+    }
+
+    #[test]
+    fn hidden_dirs_filtered() {
+        assert!(!is_relevant_change(
+            Path::new("/workspace/.swarmnote/db.sqlite"),
+            &ws()
+        ));
+        assert!(!is_relevant_change(
+            Path::new("/workspace/.git/HEAD"),
+            &ws()
+        ));
+    }
+
+    #[test]
+    fn non_md_files_filtered() {
+        assert!(!is_relevant_change(
+            Path::new("/workspace/image.png"),
+            &ws()
+        ));
+    }
+
+    #[test]
+    fn md_files_relevant() {
+        // This test checks the extension logic (file may not exist on disk)
+        let path = Path::new("/workspace/note.md");
+        // When path doesn't exist, is_relevant_change checks extension
+        assert!(is_relevant_change(path, &ws()));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod db;
 pub mod error;
+mod fs;
 mod identity;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -20,15 +21,22 @@ pub fn run() {
             db::commands::db_get_folders,
             db::commands::db_create_folder,
             db::commands::db_delete_folder,
+            fs::commands::scan_workspace_tree,
+            fs::commands::fs_create_file,
+            fs::commands::fs_create_dir,
+            fs::commands::fs_delete_file,
+            fs::commands::fs_delete_dir,
+            fs::commands::fs_rename,
         ])
         .setup(|app| {
+            use tauri::Manager;
             // From<IdentityError> for AppError allows ? directly
             identity::init(app.handle())?;
             db::init(app.handle())?;
+            app.manage(fs::watcher::FsWatcherState::new());
 
             #[cfg(not(target_os = "macos"))]
             {
-                use tauri::Manager;
                 let window = app.get_webview_window("main").unwrap();
                 window.set_decorations(false)?;
             }

--- a/src/commands/fs.ts
+++ b/src/commands/fs.ts
@@ -1,0 +1,31 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface FileTreeNode {
+  id: string;
+  name: string;
+  children?: FileTreeNode[];
+}
+
+export function scanWorkspaceTree(): Promise<FileTreeNode[]> {
+  return invoke<FileTreeNode[]>("scan_workspace_tree");
+}
+
+export function fsCreateFile(parentRel: string, name: string): Promise<string> {
+  return invoke<string>("fs_create_file", { parentRel, name });
+}
+
+export function fsCreateDir(parentRel: string, name: string): Promise<string> {
+  return invoke<string>("fs_create_dir", { parentRel, name });
+}
+
+export function fsDeleteFile(relPath: string): Promise<void> {
+  return invoke<void>("fs_delete_file", { relPath });
+}
+
+export function fsDeleteDir(relPath: string): Promise<void> {
+  return invoke<void>("fs_delete_dir", { relPath });
+}
+
+export function fsRename(relPath: string, newName: string): Promise<string> {
+  return invoke<string>("fs_rename", { relPath, newName });
+}

--- a/src/components/filetree/EmptyTreeState.tsx
+++ b/src/components/filetree/EmptyTreeState.tsx
@@ -1,0 +1,16 @@
+import { Trans } from "@lingui/react/macro";
+import { FileText } from "lucide-react";
+
+export function EmptyTreeState() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-2 px-4 py-8 text-center">
+      <FileText className="h-8 w-8 text-muted-foreground/50" />
+      <p className="text-sm text-muted-foreground">
+        <Trans>还没有笔记</Trans>
+      </p>
+      <p className="text-xs text-muted-foreground/70">
+        <Trans>点击上方 + 创建第一篇</Trans>
+      </p>
+    </div>
+  );
+}

--- a/src/components/filetree/FileTree.tsx
+++ b/src/components/filetree/FileTree.tsx
@@ -1,0 +1,158 @@
+import { useLingui } from "@lingui/react/macro";
+import { ask } from "@tauri-apps/plugin-dialog";
+import { useCallback, useRef } from "react";
+import type { NodeApi } from "react-arborist";
+import { Tree, type TreeApi } from "react-arborist";
+import type { FileTreeNode } from "@/commands/fs";
+import { useEditorStore } from "@/stores/editorStore";
+import { useFileTreeStore } from "@/stores/fileTreeStore";
+import { EmptyTreeState } from "./EmptyTreeState";
+import { FileTreeContextMenu } from "./FileTreeContextMenu";
+import { FileTreeNodeRenderer } from "./FileTreeNode";
+
+interface FileTreeProps {
+  width: number;
+  height: number;
+}
+
+export function FileTree({ width, height }: FileTreeProps) {
+  const { t } = useLingui();
+  const tree = useFileTreeStore((s) => s.tree);
+  const isLoading = useFileTreeStore((s) => s.isLoading);
+  const createFile = useFileTreeStore((s) => s.createFile);
+  const createDir = useFileTreeStore((s) => s.createDir);
+  const deleteFile = useFileTreeStore((s) => s.deleteFile);
+  const deleteDir = useFileTreeStore((s) => s.deleteDir);
+  const rename = useFileTreeStore((s) => s.rename);
+  const selectFile = useFileTreeStore((s) => s.selectFile);
+  const loadDocument = useEditorStore((s) => s.loadDocument);
+
+  const treeRef = useRef<TreeApi<FileTreeNode>>(null);
+
+  const handleCreateFile = useCallback(
+    async (parentRel: string) => {
+      const relPath = await createFile(parentRel, t`新建笔记`);
+      // Select the new file and enter rename mode
+      setTimeout(() => {
+        const node = treeRef.current?.get(relPath);
+        if (node) {
+          node.select();
+          node.edit();
+        }
+      }, 100);
+    },
+    [createFile, t],
+  );
+
+  const handleCreateDir = useCallback(
+    async (parentRel: string) => {
+      const relPath = await createDir(parentRel, t`新建文件夹`);
+      setTimeout(() => {
+        const node = treeRef.current?.get(relPath);
+        if (node) {
+          node.select();
+          node.edit();
+        }
+      }, 100);
+    },
+    [createDir, t],
+  );
+
+  const handleDelete = useCallback(
+    async (node: NodeApi<FileTreeNode>) => {
+      const isFolder = node.isInternal;
+      const message = isFolder
+        ? t`确定要删除文件夹 "${node.data.name}" 及其所有内容吗？`
+        : t`确定要删除 "${node.data.name}" 吗？`;
+
+      const confirmed = await ask(message, {
+        title: t`确认删除`,
+        kind: "warning",
+        okLabel: t`删除`,
+        cancelLabel: t`取消`,
+      });
+
+      if (!confirmed) return;
+
+      if (isFolder) {
+        await deleteDir(node.data.id);
+      } else {
+        await deleteFile(node.data.id);
+      }
+    },
+    [deleteFile, deleteDir, t],
+  );
+
+  const handleRename = useCallback((node: NodeApi<FileTreeNode>) => {
+    node.edit();
+  }, []);
+
+  const handleRenameSubmit = useCallback(
+    async ({ id, name: newName }: { id: string; name: string }) => {
+      await rename(id, newName);
+    },
+    [rename],
+  );
+
+  const handleActivate = useCallback(
+    (node: NodeApi<FileTreeNode>) => {
+      if (node.isLeaf) {
+        selectFile(node.data.id);
+        loadDocument(node.data.id, node.data.name, node.data.id);
+      }
+    },
+    [selectFile, loadDocument],
+  );
+
+  if (isLoading && tree.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <div className="h-5 w-5 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-primary" />
+      </div>
+    );
+  }
+
+  if (tree.length === 0) {
+    return <EmptyTreeState />;
+  }
+
+  return (
+    <FileTreeContextMenu
+      node={null}
+      onCreateFile={handleCreateFile}
+      onCreateDir={handleCreateDir}
+      onDelete={handleDelete}
+      onRename={handleRename}
+    >
+      <div className="flex-1">
+        <Tree<FileTreeNode>
+          ref={treeRef}
+          data={tree}
+          width={width}
+          height={height}
+          indent={16}
+          rowHeight={28}
+          openByDefault={false}
+          disableDrag
+          disableDrop
+          onRename={handleRenameSubmit}
+          onActivate={handleActivate}
+        >
+          {(props) => (
+            <FileTreeContextMenu
+              node={props.node}
+              onCreateFile={handleCreateFile}
+              onCreateDir={handleCreateDir}
+              onDelete={handleDelete}
+              onRename={handleRename}
+            >
+              <div>
+                <FileTreeNodeRenderer {...props} />
+              </div>
+            </FileTreeContextMenu>
+          )}
+        </Tree>
+      </div>
+    </FileTreeContextMenu>
+  );
+}

--- a/src/components/filetree/FileTreeContextMenu.tsx
+++ b/src/components/filetree/FileTreeContextMenu.tsx
@@ -1,0 +1,69 @@
+import { Trans } from "@lingui/react/macro";
+import { FilePlus, FolderPlus, Pencil, Trash2 } from "lucide-react";
+import type { NodeApi } from "react-arborist";
+import type { FileTreeNode } from "@/commands/fs";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+
+interface FileTreeContextMenuProps {
+  node: NodeApi<FileTreeNode> | null;
+  children: React.ReactNode;
+  onCreateFile: (parentRel: string) => void;
+  onCreateDir: (parentRel: string) => void;
+  onDelete: (node: NodeApi<FileTreeNode>) => void;
+  onRename: (node: NodeApi<FileTreeNode>) => void;
+}
+
+export function FileTreeContextMenu({
+  node,
+  children,
+  onCreateFile,
+  onCreateDir,
+  onDelete,
+  onRename,
+}: FileTreeContextMenuProps) {
+  const isFolder = node?.isInternal ?? true;
+  const parentRel = node ? (isFolder ? node.data.id : getParentRel(node.data.id)) : "";
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent className="w-48">
+        <ContextMenuItem onClick={() => onCreateFile(parentRel)}>
+          <FilePlus className="h-4 w-4" />
+          <Trans>新建笔记</Trans>
+        </ContextMenuItem>
+        <ContextMenuItem onClick={() => onCreateDir(parentRel)}>
+          <FolderPlus className="h-4 w-4" />
+          <Trans>新建文件夹</Trans>
+        </ContextMenuItem>
+        {node && (
+          <>
+            <ContextMenuSeparator />
+            <ContextMenuItem onClick={() => onRename(node)}>
+              <Pencil className="h-4 w-4" />
+              <Trans>重命名</Trans>
+            </ContextMenuItem>
+            <ContextMenuItem
+              className="text-destructive focus:text-destructive"
+              onClick={() => onDelete(node)}
+            >
+              <Trash2 className="h-4 w-4" />
+              <Trans>删除</Trans>
+            </ContextMenuItem>
+          </>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+function getParentRel(id: string): string {
+  const lastSlash = id.lastIndexOf("/");
+  return lastSlash === -1 ? "" : id.substring(0, lastSlash);
+}

--- a/src/components/filetree/FileTreeNode.tsx
+++ b/src/components/filetree/FileTreeNode.tsx
@@ -1,0 +1,92 @@
+import { ChevronDown, ChevronRight, FileText, Folder, FolderOpen } from "lucide-react";
+import type { NodeRendererProps } from "react-arborist";
+import type { FileTreeNode as FileTreeNodeData } from "@/commands/fs";
+import { cn } from "@/lib/utils";
+
+function RenameInput({ node }: { node: NodeRendererProps<FileTreeNodeData>["node"] }) {
+  return (
+    <input
+      // biome-ignore lint/a11y/noAutofocus: inline rename requires immediate focus
+      autoFocus
+      type="text"
+      defaultValue={node.data.name}
+      className="h-5 w-full rounded border border-primary bg-background px-1 text-[13px] outline-none"
+      onFocus={(e) => e.currentTarget.select()}
+      onBlur={() => node.reset()}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") node.reset();
+        if (e.key === "Enter") node.submit(e.currentTarget.value);
+      }}
+    />
+  );
+}
+
+export function FileTreeNodeRenderer({
+  node,
+  style,
+  dragHandle,
+}: NodeRendererProps<FileTreeNodeData>) {
+  const isSelected = node.isSelected;
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (node.isInternal) {
+      node.toggle();
+    } else {
+      node.select();
+      node.activate();
+    }
+    e.stopPropagation();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") handleClick(e as unknown as React.MouseEvent);
+  };
+
+  return (
+    <div
+      ref={dragHandle}
+      style={style}
+      role="treeitem"
+      tabIndex={-1}
+      className={cn(
+        "flex items-center gap-1 rounded px-2 py-[5px] text-[13px] cursor-default",
+        isSelected
+          ? "bg-sidebar-accent text-sidebar-accent-foreground"
+          : "text-sidebar-foreground hover:bg-sidebar-accent/50",
+      )}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+    >
+      {node.isInternal ? (
+        node.isOpen ? (
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        )
+      ) : (
+        <span className="w-3.5 shrink-0" />
+      )}
+
+      {node.isInternal ? (
+        node.isOpen ? (
+          <FolderOpen className="h-3.5 w-3.5 shrink-0 text-primary" />
+        ) : (
+          <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        )
+      ) : (
+        <FileText
+          className={cn(
+            "h-3.5 w-3.5 shrink-0",
+            isSelected ? "text-primary" : "text-muted-foreground",
+          )}
+        />
+      )}
+
+      {node.isEditing ? (
+        <RenameInput node={node} />
+      ) : (
+        <span className="truncate">{node.data.name}</span>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,10 +1,6 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import {
-  ChevronDown,
-  ChevronRight,
   FilePlus,
-  FileText,
-  Folder,
   FolderOpen,
   FolderPlus,
   Globe,
@@ -13,14 +9,15 @@ import {
   PanelLeft,
   Sun,
 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { FileTree } from "@/components/filetree/FileTree";
 import { Button } from "@/components/ui/button";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { type Locale, locales } from "@/i18n";
-import { cn, isMac, modKey } from "@/lib/utils";
+import { isMac, modKey } from "@/lib/utils";
+import { useFileTreeStore } from "@/stores/fileTreeStore";
 import { useUIStore } from "@/stores/uiStore";
-
-const treeItemBase = "flex items-center gap-1.5 rounded px-2 py-[5px] text-[13px]";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 const themeIcons = { light: Sun, dark: Moon, system: Monitor } as const;
 const themeOrder: Array<"light" | "dark" | "system"> = ["light", "dark", "system"];
@@ -34,8 +31,19 @@ export function Sidebar() {
   const setTheme = useUIStore((s) => s.setTheme);
   const locale = useUIStore((s) => s.locale);
   const setLocale = useUIStore((s) => s.setLocale);
+  const workspace = useWorkspaceStore((s) => s.workspace);
+  const rescan = useFileTreeStore((s) => s.rescan);
+  const createFile = useFileTreeStore((s) => s.createFile);
+  const createDir = useFileTreeStore((s) => s.createDir);
 
   const ThemeIcon = themeIcons[theme];
+
+  // Rescan when workspace changes
+  useEffect(() => {
+    if (workspace) {
+      rescan();
+    }
+  }, [workspace, rescan]);
 
   function cycleTheme() {
     const idx = themeOrder.indexOf(theme);
@@ -46,6 +54,32 @@ export function Sidebar() {
     const idx = localeKeys.indexOf(locale);
     setLocale(localeKeys[(idx + 1) % localeKeys.length]);
   }
+
+  const handleCreateFile = useCallback(() => {
+    createFile("", t`新建笔记`);
+  }, [createFile, t]);
+
+  const handleCreateDir = useCallback(() => {
+    createDir("", t`新建文件夹`);
+  }, [createDir, t]);
+
+  // Measure available height for the tree
+  const [treeHeight, setTreeHeight] = useState(400);
+  const treeContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = treeContainerRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setTreeHeight(entry.contentRect.height);
+      }
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <aside
@@ -60,13 +94,18 @@ export function Sidebar() {
           <div className="flex items-center gap-1.5">
             <FolderOpen className="h-4 w-4 text-sidebar-primary" />
             <span className="text-[13px] font-semibold text-sidebar-foreground">
-              <Trans>我的笔记</Trans>
+              {workspace?.name ?? <Trans>我的笔记</Trans>}
             </span>
           </div>
           <div className="flex gap-0.5">
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon-xs" className="text-muted-foreground">
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  className="text-muted-foreground"
+                  onClick={handleCreateFile}
+                >
                   <FilePlus className="h-3.5 w-3.5" />
                 </Button>
               </TooltipTrigger>
@@ -76,7 +115,12 @@ export function Sidebar() {
             </Tooltip>
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon-xs" className="text-muted-foreground">
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  className="text-muted-foreground"
+                  onClick={handleCreateDir}
+                >
                   <FolderPlus className="h-3.5 w-3.5" />
                 </Button>
               </TooltipTrigger>
@@ -102,35 +146,10 @@ export function Sidebar() {
           </div>
         </div>
 
-        {/* File Tree (static placeholder) */}
-        <ScrollArea className="flex-1">
-          <div className="flex flex-col gap-px">
-            {/* Folder: 日记 (expanded) */}
-            <div className={cn(treeItemBase, "text-sidebar-foreground")}>
-              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-              <Folder className="h-3.5 w-3.5 text-primary" />
-              <span>日记</span>
-            </div>
-            <div className={cn(treeItemBase, "bg-sidebar-accent pl-[34px]")}>
-              <FileText className="h-3.5 w-3.5 text-primary" />
-              <span className="font-medium text-sidebar-accent-foreground">2026-03-21</span>
-            </div>
-            <div className={cn(treeItemBase, "pl-[34px] text-sidebar-foreground")}>
-              <FileText className="h-3.5 w-3.5 text-muted-foreground" />
-              <span>2026-03-19</span>
-            </div>
-            {/* Folder: 项目笔记 (collapsed) */}
-            <div className={cn(treeItemBase, "text-sidebar-foreground")}>
-              <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
-              <Folder className="h-3.5 w-3.5 text-muted-foreground" />
-              <span>项目笔记</span>
-            </div>
-            <div className={cn(treeItemBase, "text-sidebar-foreground")}>
-              <FileText className="h-3.5 w-3.5 text-muted-foreground" />
-              <span>快速笔记</span>
-            </div>
-          </div>
-        </ScrollArea>
+        {/* File Tree */}
+        <div ref={treeContainerRef} className="flex-1 overflow-hidden">
+          <FileTree width={232} height={treeHeight} />
+        </div>
 
         {/* Device Info + Quick Settings */}
         <div className="flex items-center gap-2 border-t border-sidebar-border px-1 pt-2">

--- a/src/components/layout/TitleBar.tsx
+++ b/src/components/layout/TitleBar.tsx
@@ -1,7 +1,7 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useNavigate } from "@tanstack/react-router";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { Minus, PenLine, Search, Settings, Square, X } from "lucide-react";
+import { Minus, PanelLeft, PenLine, Search, Settings, Square, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { isMac, modKey } from "@/lib/utils";
@@ -12,6 +12,7 @@ export function TitleBar() {
   const navigate = useNavigate();
   const appWindow = getCurrentWindow();
   const sidebarOpen = useUIStore((s) => s.sidebarOpen);
+  const toggleSidebar = useUIStore((s) => s.toggleSidebar);
 
   // When sidebar is collapsed on macOS, add left padding to avoid traffic light overlap
   const needsTrafficLightPadding = isMac && !sidebarOpen;
@@ -26,6 +27,18 @@ export function TitleBar() {
         className={`flex items-center gap-3 ${needsTrafficLightPadding ? "pl-[70px]" : ""}`}
         data-tauri-drag-region
       >
+        {!sidebarOpen && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant="ghost" size="icon-sm" onClick={toggleSidebar}>
+                <PanelLeft className="h-4 w-4 text-muted-foreground" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {t`展开侧边栏`} ({modKey}B)
+            </TooltipContent>
+          </Tooltip>
+        )}
         <div className="flex items-center gap-1.5">
           <div className="flex h-[22px] w-[22px] items-center justify-center rounded bg-primary">
             <PenLine className="h-3.5 w-3.5 text-white" />

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { ContextMenu as ContextMenuPrimitive } from "radix-ui";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+function ContextMenu({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />;
+}
+
+function ContextMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
+  return <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />;
+}
+
+function ContextMenuContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Content
+        data-slot="context-menu-content"
+        className={cn(
+          "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          className,
+        )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  );
+}
+
+function ContextMenuItem({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Item> & { inset?: boolean }) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      className={cn(
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+        inset && "pl-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+};

--- a/src/stores/fileTreeStore.ts
+++ b/src/stores/fileTreeStore.ts
@@ -1,107 +1,99 @@
+import { listen } from "@tauri-apps/api/event";
 import { create } from "zustand";
 import {
-  type DocumentModel,
-  deleteDocument as deleteDocumentCmd,
-  getDocuments,
-  type UpsertDocumentInput,
-  upsertDocument,
-} from "@/commands/document";
-import {
-  type CreateFolderInput,
-  createFolder as createFolderCmd,
-  deleteFolder as deleteFolderCmd,
-  type FolderModel,
-  getFolders,
-} from "@/commands/folder";
+  type FileTreeNode,
+  fsCreateDir,
+  fsCreateFile,
+  fsDeleteDir,
+  fsDeleteFile,
+  fsRename,
+  scanWorkspaceTree,
+} from "@/commands/fs";
 
 interface FileTreeState {
-  documents: DocumentModel[];
-  folders: FolderModel[];
-  selectedFile: string | null;
-  expandedFolders: Set<string>;
+  tree: FileTreeNode[];
+  selectedId: string | null;
   isLoading: boolean;
 }
 
 interface FileTreeActions {
-  loadTree: (workspaceId: string) => Promise<void>;
+  rescan: () => Promise<void>;
   selectFile: (id: string | null) => void;
-  toggleFolder: (folderId: string) => void;
-  createDocument: (input: UpsertDocumentInput) => Promise<DocumentModel>;
-  deleteDocument: (id: string) => Promise<void>;
-  createFolder: (input: CreateFolderInput) => Promise<FolderModel>;
-  deleteFolder: (id: string) => Promise<void>;
+  createFile: (parentRel: string, name: string) => Promise<string>;
+  createDir: (parentRel: string, name: string) => Promise<string>;
+  deleteFile: (relPath: string) => Promise<void>;
+  deleteDir: (relPath: string) => Promise<void>;
+  rename: (relPath: string, newName: string) => Promise<string>;
   clear: () => void;
 }
 
 const initialState: FileTreeState = {
-  documents: [],
-  folders: [],
-  selectedFile: null,
-  expandedFolders: new Set<string>(),
+  tree: [],
+  selectedId: null,
   isLoading: false,
 };
 
 export const useFileTreeStore = create<FileTreeState & FileTreeActions>()((set, get) => ({
   ...initialState,
 
-  loadTree: async (workspaceId) => {
+  rescan: async () => {
     set({ isLoading: true });
     try {
-      const [docs, dirs] = await Promise.all([getDocuments(workspaceId), getFolders(workspaceId)]);
-      set({ documents: docs, folders: dirs });
+      const tree = await scanWorkspaceTree();
+      set({ tree });
     } finally {
       set({ isLoading: false });
     }
   },
 
-  selectFile: (id) => set({ selectedFile: id }),
+  selectFile: (id) => set({ selectedId: id }),
 
-  toggleFolder: (folderId) => {
-    const { expandedFolders } = get();
-    const next = new Set(expandedFolders);
-    if (next.has(folderId)) {
-      next.delete(folderId);
-    } else {
-      next.add(folderId);
+  createFile: async (parentRel, name) => {
+    const relPath = await fsCreateFile(parentRel, name);
+    await get().rescan();
+    return relPath;
+  },
+
+  createDir: async (parentRel, name) => {
+    const relPath = await fsCreateDir(parentRel, name);
+    await get().rescan();
+    return relPath;
+  },
+
+  deleteFile: async (relPath) => {
+    await fsDeleteFile(relPath);
+    const { selectedId } = get();
+    if (selectedId === relPath) {
+      set({ selectedId: null });
     }
-    set({ expandedFolders: next });
+    await get().rescan();
   },
 
-  createDocument: async (input) => {
-    const doc = await upsertDocument(input);
-    set((s) => ({
-      documents: input.id
-        ? s.documents.map((d) => (d.id === doc.id ? doc : d))
-        : [...s.documents, doc],
-    }));
-    return doc;
+  deleteDir: async (relPath) => {
+    await fsDeleteDir(relPath);
+    await get().rescan();
   },
 
-  deleteDocument: async (id) => {
-    await deleteDocumentCmd(id);
-    set((s) => ({
-      documents: s.documents.filter((d) => d.id !== id),
-      selectedFile: s.selectedFile === id ? null : s.selectedFile,
-    }));
-  },
-
-  createFolder: async (input) => {
-    const folder = await createFolderCmd(input);
-    set((s) => ({ folders: [...s.folders, folder] }));
-    return folder;
-  },
-
-  deleteFolder: async (id) => {
-    await deleteFolderCmd(id);
-    set((s) => ({
-      folders: s.folders.filter((f) => f.id !== id),
-      documents: s.documents.filter((d) => d.folder_id !== id),
-      selectedFile:
-        s.selectedFile && s.documents.some((d) => d.folder_id === id && d.id === s.selectedFile)
-          ? null
-          : s.selectedFile,
-    }));
+  rename: async (relPath, newName) => {
+    const newRelPath = await fsRename(relPath, newName);
+    const { selectedId } = get();
+    if (selectedId === relPath) {
+      set({ selectedId: newRelPath });
+    }
+    await get().rescan();
+    return newRelPath;
   },
 
   clear: () => set(initialState),
 }));
+
+// Register fs:tree-changed listener with throttle
+let throttleTimer: ReturnType<typeof setTimeout> | null = null;
+
+listen("fs:tree-changed", () => {
+  if (throttleTimer) return;
+  throttleTimer = setTimeout(() => {
+    throttleTimer = null;
+    useFileTreeStore.getState().rescan();
+  }, 200);
+});


### PR DESCRIPTION
## Summary
- 新增 Rust `fs` 模块：递归扫描工作区目录、文件/文件夹 CRUD（含路径安全校验和冲突自动编号）、notify crate 文件系统监听（debounce + 事件过滤）
- 新增 6 个 Tauri 命令：`scan_workspace_tree`、`fs_create_file/dir`、`fs_delete_file/dir`、`fs_rename`
- 重写侧边栏为 react-arborist 文件树组件，支持右键菜单、行内重命名、删除确认、空状态提示
- fileTreeStore 从 DB 驱动切换为文件系统驱动，自动监听 `fs:tree-changed` 事件刷新
- TitleBar 增加侧边栏展开按钮（折叠时可见）
- 16 个 Rust 单元测试覆盖 scan 和 crud 模块

## Test plan
- [x] `cargo test` — 31 tests passed
- [x] `cargo clippy -- -D warnings` — 0 warnings
- [x] `pnpm lint:ci` — 0 errors
- [ ] 手动验证：打开工作区 → 文件树显示 → 新建/删除/重命名 → 外部修改自动刷新

Closes #8