### PR TITLE
feat(p2p): integrate swarm-p2p-core into Tauri backend (#24)

### DIFF
--- a/dev-notes/research/mobile-filesystem-and-resources.md
+++ b/dev-notes/research/mobile-filesystem-and-resources.md
@@ -1,0 +1,227 @@
+# 移动端文件系统与资源文件策略
+
+> 调研日期：2026-03-26
+> 目的：分析 Android/iOS 沙盒文件系统对 SwarmNote 移动端的影响，确定资源文件（图片/视频）处理方案
+
+---
+
+## 一、移动端文件系统限制
+
+### 1.1 Android (Scoped Storage, Android 11+)
+
+Android 10 引入、Android 11 强制执行 Scoped Storage，应用只能自由访问自己的沙盒目录。
+
+| 方案 | 说明 | 限制 |
+|---|---|---|
+| App 私有目录 `/Android/data/<pkg>/` | 无需权限，卸载时删除 | 用户不可见，其他 app 无法访问 |
+| SAF `ACTION_OPEN_DOCUMENT_TREE` | 用户选择目录后授予持久访问 | Android 11+ 禁止选根目录/Downloads/SD卡根 |
+| MediaStore + `Documents/` | 写入共享 Documents 目录 | 只能看到自己创建的文件 |
+| `MANAGE_EXTERNAL_STORAGE` | 完全外部存储权限 | Google Play 严格限审，笔记应用基本不会通过 |
+
+**Obsidian 在 Android 的做法**：默认存在 `/Android/data/md.obsidian/files/`（用户不可见），或通过 SAF 让用户选文件夹（Android 13+ 限制增多，社区抱怨不断）。
+
+### 1.2 iOS (严格沙盒)
+
+| 方案 | 说明 | 限制 |
+|---|---|---|
+| App 沙盒 `Documents/` | 默认方案 | 其他 app 无法直接访问 |
+| File Provider Extension | 在"文件" app 中显示 | 需写原生扩展，Expo 不直接支持 |
+| iCloud Container | 自动同步 | 依赖 Apple 生态 |
+| Document Picker | 可选择外部文件 | 用户体验割裂 |
+
+### 1.3 对 SwarmNote 的影响
+
+**P2P 同步不受影响**：同步发生在 yjs CRDT + 数据库层，不依赖文件系统。
+
+**受影响的是 "Markdown 文件即真相源" 设计原则**：
+
+| 桌面端设计 | 移动端现实 |
+|---|---|
+| 用户能直接浏览 `.md` 文件 | 沙盒内文件用户不可见 |
+| 可以用 Obsidian 打开同一目录 | 跨 app 访问需要 SAF/File Provider |
+| 文件夹就是组织结构 | 文件夹在沙盒内，用户感知不到 |
+| 删库了从 `.md` 重建 | `.md` 和 SQLite 都在沙盒内，没本质区别 |
+
+---
+
+## 二、存储分层策略
+
+桌面和移动端使用不同的"真相源"定义：
+
+```
+┌──────────────────────────────────────────────────┐
+│              SwarmNote 存储分层                    │
+├──────────────┬──────────────┬────────────────────┤
+│  桌面端       │  移动端       │  同步层             │
+├──────────────┼──────────────┼────────────────────┤
+│ .md 文件      │ SQLite       │ yjs CRDT 更新       │
+│ (真相源)      │ (真相源)      │ (平台无关)          │
+│ SQLite 索引   │ .md 导出功能  │ swarm-p2p-core     │
+│ (可重建)      │ (用户需要时)   │ (libp2p)           │
+└──────────────┴──────────────┴────────────────────┘
+```
+
+- **移动端以 SQLite 为主存储**，不再维护实时的 `.md` 文件系统
+- **提供"导出到文件"功能**，用户需要时可批量导出为 `.md`
+- **同步层不变**，yjs CRDT 更新在桌面端写入 `.md` + SQLite 索引，在移动端只写入 SQLite
+- **桌面端保持现有架构**，`.md` 文件仍然是真相源
+
+---
+
+## 三、资源文件（图片/视频）处理方案
+
+### 3.1 桌面端现有设计
+
+```
+Document.md              ← 文本引用 ![](Document/screenshot.png)
+Document/
+  ├── screenshot.png      ← 图片
+  └── demo.mp4            ← 视频
+```
+
+### 3.2 移动端方案：SQLite 元数据 + 沙盒文件存储
+
+```
+App Sandbox/
+├── swarmnote.db                    ← SQLite (笔记文本 + 元数据)
+└── resources/                      ← 资源文件目录
+    ├── a1b2c3d4.png                ← content-hash 命名
+    ├── e5f6g7h8.jpg
+    └── i9j0k1l2.mp4
+```
+
+文本在 SQLite，资源文件在沙盒目录，用 content-hash (BLAKE3) 作为文件名。
+
+### 3.3 数据模型
+
+```sql
+-- 资源表
+CREATE TABLE resources (
+  id          TEXT PRIMARY KEY,        -- UUID
+  hash        TEXT NOT NULL UNIQUE,    -- BLAKE3 content hash（去重用）
+  filename    TEXT NOT NULL,           -- 原始文件名 screenshot.png
+  mime_type   TEXT NOT NULL,           -- image/png, video/mp4
+  size        INTEGER NOT NULL,        -- 字节数
+  width       INTEGER,                 -- 图片/视频宽度
+  height      INTEGER,                 -- 图片/视频高度
+  duration    INTEGER,                 -- 视频时长(ms)
+  thumbnail   BLOB,                    -- 缩略图（几 KB，存 BLOB 没问题）
+  local_path  TEXT,                    -- 本地沙盒路径（可能为空=未下载）
+  sync_state  TEXT DEFAULT 'local',    -- local / syncing / synced
+  created_at  INTEGER NOT NULL
+);
+
+-- 笔记-资源关联
+CREATE TABLE doc_resources (
+  doc_id      TEXT NOT NULL,
+  resource_id TEXT NOT NULL,
+  PRIMARY KEY (doc_id, resource_id)
+);
+```
+
+### 3.4 Content-hash 命名的好处
+
+```
+用户插入 screenshot.png
+  → BLAKE3 hash → a1b2c3d4...
+  → 存为 resources/a1b2c3d4.png
+  → 笔记中引用 swarmnote://resource/a1b2c3d4
+```
+
+1. **天然去重**：同一张图插入多篇笔记，只存一份
+2. **完整性校验**：同步时 hash 对比即可验证
+3. **与 SwarmDrop 一致**：swarmdrop 的传输协议已经用 BLAKE3 做 chunk 校验
+
+### 3.5 桌面 ↔ 移动引用转换
+
+同步时需要做一层引用格式转换：
+
+```
+桌面 → 移动：
+  相对路径 Document/screenshot.png
+  → 下载文件到 resources/
+  → 计算 hash → 写入 resources 表
+  → 笔记中替换为 swarmnote://resource/{hash}
+
+移动 → 桌面：
+  swarmnote://resource/{hash}
+  → 查 resources 表获取原始文件名
+  → 复制到 Document/ 目录
+  → 笔记中替换为相对路径
+```
+
+这层转换放在 Rust `app-core` 的同步模块里，对上层透明。
+
+---
+
+## 四、大文件同步策略
+
+利用 SwarmNote 已设计的三级同步架构：
+
+| 文件类型 | 同步级别 | 策略 |
+|---|---|---|
+| 小图片 (<1MB) | L3 全文件 | 直接传输，hash 比对 |
+| 大图片/视频 (>1MB) | L2 FastCDC 分块 | 256KB 分块 + BLAKE3，支持断点续传 |
+| 缩略图 | 随 SQLite 同步 | BLOB 字段，几 KB |
+
+### 按需下载（省空间）
+
+```
+移动端收到同步：
+  1. 先同步元数据（hash, size, mime_type, thumbnail）→ 立即可预览缩略图
+  2. 用户点开笔记时再下载原图/视频
+  3. local_path 为空 = 未下载，显示缩略图 + 下载按钮
+  4. 存储空间不足时可清理已下载的原文件，保留缩略图
+```
+
+类似 iCloud 照片的"优化存储空间"。
+
+---
+
+## 五、RN 端实现工具链
+
+| 功能 | 库 | 说明 |
+|---|---|---|
+| 相机拍照 | `expo-camera` / `expo-image-picker` | 拍照后复制到 resources/ |
+| 相册选取 | `expo-image-picker` | 支持多选、视频 |
+| 文件操作 | `expo-file-system` (SDK 54 新 API) | `File` / `Directory` 类，原生支持 SAF 和 Security Scoped Resources |
+| 图片压缩 | `expo-image-manipulator` | 插入前可压缩 |
+| 视频缩略图 | `expo-video-thumbnails` | 生成预览帧 |
+| 图片显示 | `expo-image` | 支持缓存和渐进加载 |
+| 剪贴板 | `expo-clipboard` | 粘贴图片 |
+| 文件导出 | `expo-sharing` + `expo-file-system` | 导出 .md + 资源文件 |
+
+均为 Expo 官方库，与 Expo 54 技术栈兼容。
+
+---
+
+## 六、主流笔记 App 的移动端策略参考
+
+| App | 存储方式 | 文件可见性 | 同步 |
+|---|---|---|---|
+| **Obsidian** | 文件系统 `.md` | Android: SAF / 私有目录; iOS: iCloud | Obsidian Sync / iCloud / Syncthing |
+| **Joplin** | SQLite 数据库 | 不可见，需导出 | REST API + 云存储 |
+| **Logseq** | 文件系统 (正迁移 SQLite) | 类似 Obsidian | Logseq Sync / iCloud / Git |
+| **Notesnook** | SQLite | 不可见 | 自建同步 |
+
+**趋势**：Logseq 正从文件系统迁移到 SQLite，说明纯文件系统方案在移动端摩擦太大。
+
+---
+
+## 七、总结
+
+```
+┌──────────────────────────────────────────────────┐
+│               资源文件处理架构                     │
+├───────────┬──────────────┬───────────────────────┤
+│  桌面端    │   移动端      │   P2P 同步             │
+├───────────┼──────────────┼───────────────────────┤
+│ 文件系统   │ 沙盒文件      │ 元数据优先同步          │
+│ 相对路径   │ content-hash │ 原文件按需下载           │
+│ 原始文件名 │ 缩略图在 DB   │ FastCDC 分块传大文件    │
+│ 无去重     │ hash 自动去重 │ BLAKE3 校验            │
+└───────────┴──────────────┴───────────────────────┘
+             ↕ 引用转换层 (Rust app-core)
+```
+
+移动端资源文件不需要用户可见，只要 app 内正常显示、导出时能还原原始文件名即可。沙盒限制因此不再是问题。

--- a/dev-notes/research/rn-rust-bridge-research.md
+++ b/dev-notes/research/rn-rust-bridge-research.md
@@ -1,0 +1,212 @@
+# React Native 桥接 Rust 代码方案调研
+
+> 调研日期：2026-03-26
+> 目的：评估 swarmnote 移动端使用 RN + Rust 架构的可行性，复用 swarmdrop 的 P2P 核心
+
+---
+
+## 一、背景
+
+swarmnote 后续需要做移动端。swarmdrop 已有成熟的 Rust 后端（libp2p P2P 网络、E2E 加密传输、SeaORM 持久化等），目前通过 Tauri 的 `#[tauri::command]` 暴露给前端。目标是找到一种方案，让 React Native 能像 Tauri 一样调用 Rust 代码，实现核心逻辑跨平台复用。
+
+---
+
+## 二、方案对比
+
+### 2.1 uniffi-bindgen-react-native (Mozilla / Filament)
+
+- **仓库**: [jhugman/uniffi-bindgen-react-native](https://github.com/jhugman/uniffi-bindgen-react-native) | 484 stars
+- **原理**: 基于 Mozilla UniFFI，通过 `#[uniffi::export]` 注解 Rust 代码，自动生成 TypeScript + C++ (JSI) 绑定，最终生成标准 React Native Turbo Module
+- **链路**: JS → Hermes JSI → C++ → Rust (xcframework / .so)
+- **DX 示例**:
+
+```rust
+// Rust 端
+#[uniffi::export]
+pub async fn say_after(ms: u64, who: String) -> String {
+    format!("Hello, {who}!")
+}
+```
+
+```typescript
+// TypeScript 端 — 自动生成类型，直接函数调用
+const message = await sayAfter(1000n, "World");
+// 支持 AbortSignal 取消
+const msg = await sayAfter(60000n, "World", { signal: controller.signal });
+```
+
+- **类型安全**: 完全自动生成 TS 类型声明，支持枚举、结构体、对象（带方法和 GC 集成）、回调
+- **异步**: 完整支持。async fn → Promise，��持 AbortSignal 取消（内部 drop Future），双向异步调用
+- **平台**: iOS + Android + WASM (Web)
+- **成熟度**: Mozilla 已在 Firefox 移动端大规模使用，服务数亿用户
+- **评价**: **当前首选**，DX 最接近 Tauri，功能最完整
+
+### 2.2 Craby
+
+- **仓库**: [leegeunhyeok/craby](https://github.com/leegeunhyeok/craby) | 220 stars
+- **原理**: 与 uniffi 方向相反 — 从 TypeScript Schema 出发生成 Rust/C++ 绑定，直接集成纯 C++ TurboModule
+- **DX**: 在 TS 中定义模块接口 (Spec)，运行 `craby generate` 生成 Rust 骨架，用 `#[craby_module]` 实现
+- **独特功能**: Signals（Rust → JS 单向事件推送）
+- **平台**: iOS + Android
+- **成熟度**: RC 阶段，社区较小
+- **限制**: 不支持返回 Uint8Array / ArrayBuffer
+- **评价**: TypeScript-first 设计对前端开发者友好，但成熟度不够
+
+### 2.3 Ferric + Node-API (Callstack)
+
+- **仓库**: [callstackincubator/react-native-node-api](https://github.com/callstackincubator/react-native-node-api) | 183 stars
+- **原理**: 利用 Node-API (N-API) 作为 ABI 稳定接口，基于 napi-rs 生成绑定
+- **DX**: 使用 `#[napi]` 宏（与 Node.js napi-rs 生态完全一致）
+- **核心优势**: 与 Node.js / Deno / Bun 生态共享代码，预构建二进制分发
+- **平台**: iOS + Android
+- **成熟度**: 早期开发，依赖 Hermes 自定义版本
+- **评价**: **未来最值得关注**，一旦 Hermes 官方合并 Node-API 将成为标准方案
+
+### 2.4 其他方案（不推荐）
+
+| 方案 | 问题 |
+|---|---|
+| **jsi-rs** (211 stars) | 已停止维护 (2024-10)，仅支持 Android，async 阻塞式 |
+| **Nitro + Rust** | Nitro 成熟但 Rust 非官方支持，需手写 C FFI 胶水层 |
+| **手动 C Bridge + JSI** | 全手工，容易内存泄漏，工作量大 |
+
+---
+
+## 三、与 Tauri 的 DX 对比
+
+| 维度 | Tauri | uniffi-bindgen-rn | Ferric (napi-rs) |
+|---|---|---|---|
+| **定义方式** | `#[tauri::command]` | `#[uniffi::export]` | `#[napi]` |
+| **调用方式** | `invoke('name', args)` | 直接函数调用 | 直接函数调用 |
+| **序列化** | JSON (serde) | 无（JSI 直通） | 无（Node-API 直通） |
+| **类型安全** | 运行时 (serde) | 编译时 + 生成 TS | 编译时 + 生成 TS |
+| **IPC 开销** | 较高（WebView fetch） | 低（JSI 直调） | 低（Node-API） |
+| **异步** | async command | async fn → Promise + AbortSignal | async fn → Promise |
+
+**结论**: RN 方案在性能和类型安全上甚至优于 Tauri（绕过 WebView 层，无 JSON 序列化开销）。
+
+---
+
+## 四、SwarmDrop 代码桥接可行性分析
+
+### 4.1 架构现状
+
+```
+swarmdrop/
+├── libs/core/           ← swarm-p2p-core (纯 Rust，无 Tauri 依赖)
+│   ├── client/          ← NetClient API
+│   ├── runtime/         ← libp2p behaviours
+│   ├── config.rs        ← NodeConfig
+│   └── event.rs         ← NodeEvent 枚举
+├── src-tauri/src/       ← 应用层逻辑 (重度依赖 Tauri)
+│   ├── commands/        ← Tauri IPC 命令
+│   ├── network/         ← NetManager
+│   ├── pairing/         ← PairingManager
+│   ├── transfer/        ← SendSession/ReceiveSession + 加密
+│   ├── file_source/     ← 文件枚举/读取
+│   ├── file_sink/       ← 文件写入 (Android SAF)
+│   ├── database/        ← SeaORM + SQLite
+│   └── mcp/             ← MCP server
+└── src/                 ← React 前端
+```
+
+### 4.2 可直接桥接的部分 (~60%)
+
+| 模块 | 说明 | UniFFI 兼容性 |
+|---|---|---|
+| `libs/core` | 纯 Rust P2P 核心，无 Tauri 依赖 | ✅ 直接 `#[uniffi::export]` |
+| `transfer/crypto.rs` | XChaCha20-Poly1305 加密 | ✅ 纯算法 |
+| `pairing/` 核心逻辑 | 配对协议、DHT 操作 | ✅ 业务逻辑可复用 |
+| `transfer/` 核心逻辑 | 发送/接收会话、分块传输 | ✅ 协议层可复用 |
+| `database/` | SeaORM + SQLite | ✅ SQLite 在移动端原生支持 |
+| `protocol.rs` | CBOR 请求/响应定义 | ✅ 纯数据结构 |
+
+### 4.3 需要适配/重写的部分 (~40%)
+
+| 模块 | 问题 | 解决方案 |
+|---|---|---|
+| `commands/` | `#[tauri::command]` | → `#[uniffi::export]` |
+| 事件系统 | `app.emit()` Tauri 专有 | → uniffi callback interface |
+| Stronghold 密钥存储 | `tauri-plugin-stronghold` | → RN 侧 `expo-secure-store` + Rust 接收密钥 |
+| `file_sink/android_ops.rs` | Tauri Android 插件 (SAF) | → RN 侧处理文件选择，Rust 侧只做 I/O |
+| `network/` NetManager | `tauri::AppHandle` 管理状态 | → 独立 Rust struct + `Arc` |
+
+### 4.4 关键依赖移动端兼容性
+
+| 依赖 | 可用 | 备注 |
+|---|---|---|
+| libp2p 0.56 | ✅ | 已有移动端案例 (IPFS Mobile, Firefox) |
+| tokio | ✅ | 移动端标准 async runtime |
+| chacha20poly1305 + blake3 | ✅ | 纯 Rust，无 C 依赖 |
+| sea-orm + sqlx + sqlite | ✅ | SQLite 原生支持 |
+| serde + serde_cbor | ✅ | 纯 Rust |
+| ed25519-dalek | ✅ | 纯 Rust |
+| dashmap | ✅ | 纯 Rust |
+
+**无不可移植依赖**。
+
+---
+
+## 五、推荐重构策略
+
+### 5.1 架构目标
+
+```
+swarmdrop/
+├── libs/core/            ← 保持不变
+├── libs/app-core/        ← 🆕 从 src-tauri 抽取的平台无关层
+│   ├── src/
+│   │   ├── lib.rs        ← #[uniffi::export] 所有 API
+│   │   ├── network.rs    ← NetManager (去掉 AppHandle)
+│   │   ├── pairing.rs    ← PairingManager
+│   │   ├── transfer.rs   ← TransferManager
+│   │   ├── crypto.rs     ← 加密模块
+│   │   ├── database.rs   ← SeaORM ops
+│   │   └── callback.rs   ← #[uniffi::export(callback_interface)]
+│   └── Cargo.toml
+├── src-tauri/             ← Tauri 桌面端 (薄层，调用 app-core)
+└── swarmnote/             ← 🆕 RN 移动端 (uniffi-bindgen-react-native)
+```
+
+### 5.2 事件推送方案（替代 Tauri emit）
+
+```rust
+// Rust 端 - uniffi callback interface
+#[uniffi::export(callback_interface)]
+pub trait SwarmEventListener: Send + Sync {
+    fn on_transfer_progress(&self, session_id: String, progress: TransferProgress);
+    fn on_pairing_request(&self, peer_id: String, os_info: OsInfo);
+    fn on_network_status_changed(&self, status: NetworkStatus);
+    fn on_peer_discovered(&self, peer_id: String, name: String);
+}
+
+// RN/TS 端
+const listener: SwarmEventListener = {
+    onTransferProgress(sessionId, progress) { /* 更新 UI */ },
+    onPairingRequest(peerId, osInfo) { /* 弹窗确认 */ },
+};
+await swarmCore.start(config, listener);
+```
+
+### 5.3 命令映射
+
+```rust
+// Tauri (现在)                              UniFFI (之后)
+#[tauri::command]                            #[uniffi::export]
+async fn start(app, keypair, ...)            async fn start(config, listener)
+
+#[tauri::command]                            #[uniffi::export]
+async fn generate_pairing_code(app)          async fn generate_pairing_code()
+```
+
+---
+
+## 六、结论
+
+**完全可行**。推荐方案：**uniffi-bindgen-react-native**。
+
+1. **代码复用率高**: `libs/core` 完全不变，`src-tauri` 约 60% 业务逻辑可搬到 `app-core`
+2. **无不可移植依赖**: libp2p、tokio、chacha20、sea-orm 全部支持移动端
+3. **异步完美匹配**: swarmdrop 重度使用 tokio async，uniffi 原生支持 async fn → Promise
+4. **事件系统有方案**: uniffi callback interface 替代 Tauri emit，类型安全
+5. **DX 优于 Tauri**: 直接函数调用 + 编译时类型安全 + 无 JSON 序列化开销

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -696,11 +696,20 @@ dependencies = [
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.3",
 ]
 
 [[package]]
@@ -809,6 +818,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -1582,9 +1597,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.3",
 ]
 
 [[package]]
@@ -2733,7 +2748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc50b891e4acf8fe0e71ef88ec43ad82ee07b3810ad09de10f1d01f072ed4b98"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -2896,6 +2911,21 @@ dependencies = [
  "tokio",
  "url",
  "xmltree",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -4001,6 +4031,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4010,12 +4050,12 @@ dependencies = [
  "dpi",
  "gtk",
  "keyboard-types",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -4248,6 +4288,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4341,6 +4390,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4352,23 +4417,52 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-app-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
+ "objc2 0.6.3",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-core-image",
+ "objc2-core-image 0.3.2",
  "objc2-core-text",
  "objc2-core-video",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4378,8 +4472,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4389,8 +4506,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -4401,7 +4518,7 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
  "dispatch2",
- "objc2",
+ "objc2 0.6.3",
 ]
 
 [[package]]
@@ -4412,9 +4529,21 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.0",
  "dispatch2",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -4423,8 +4552,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-contacts",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4434,7 +4575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-core-graphics",
 ]
@@ -4446,7 +4587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-io-surface",
@@ -4469,14 +4610,26 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
 ]
 
@@ -4487,7 +4640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
 ]
 
@@ -4497,8 +4650,45 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586"
 dependencies = [
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -4508,9 +4698,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -4520,8 +4710,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-cloud-kit 0.2.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+ "objc2-link-presentation",
+ "objc2-quartz-core 0.2.2",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
 ]
 
 [[package]]
@@ -4531,9 +4752,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-web-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68bc69301064cebefc6c4c90ce9cba69225239e4b8ff99d445a2b5563797da65"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4543,11 +4801,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
- "objc2",
- "objc2-app-kit",
+ "block2 0.6.2",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-javascript-core",
  "objc2-security",
 ]
@@ -4985,6 +5243,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5202,6 +5473,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "quick-protobuf"
@@ -5574,17 +5851,17 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
 dependencies = [
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "glib-sys",
  "gobject-sys",
  "gtk-sys",
  "js-sys",
  "log",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "raw-window-handle",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -6115,6 +6392,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6404,11 +6691,11 @@ dependencies = [
  "bytemuck",
  "js-sys",
  "ndk",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
  "raw-window-handle",
  "redox_syscall 0.5.18",
  "tracing",
@@ -6753,6 +7040,7 @@ name = "swarmnote"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "dashmap",
  "directories",
  "entity",
  "hostname",
@@ -6763,16 +7051,22 @@ dependencies = [
  "notify-debouncer-mini",
  "sea-orm",
  "serde",
+ "serde_bytes",
  "serde_json",
+ "sha2",
  "swarm-p2p-core",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-mcp-bridge",
  "tauri-plugin-opener",
  "tauri-plugin-store",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -6876,7 +7170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.6.2",
  "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
@@ -6893,9 +7187,9 @@ dependencies = [
  "ndk",
  "ndk-context",
  "ndk-sys",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "parking_lot",
  "raw-window-handle",
@@ -6954,11 +7248,11 @@ dependencies = [
  "log",
  "mime",
  "muda",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
- "objc2-ui-kit",
- "objc2-web-kit",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "objc2-web-kit 0.3.2",
  "percent-encoding",
  "plist",
  "raw-window-handle",
@@ -7016,7 +7310,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -7104,6 +7398,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-mcp-bridge"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11990bf5e3b26b253e1213f2df2db85d06f32623abd755d3fe1ca942965b0d2"
+dependencies = [
+ "base64 0.22.1",
+ "block2 0.5.1",
+ "futures-util",
+ "image",
+ "jni",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit 0.2.2",
+ "objc2-web-kit 0.2.2",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-tungstenite",
+ "uuid",
+ "webview2-com",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7111,8 +7434,8 @@ checksum = "fc624469b06f59f5a29f874bbc61a2ed737c0f9c23ef09855a292c389c42e83f"
 dependencies = [
  "dunce",
  "glob",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "open",
  "schemars 0.8.22",
  "serde",
@@ -7152,9 +7475,9 @@ dependencies = [
  "gtk",
  "http",
  "jni",
- "objc2",
- "objc2-ui-kit",
- "objc2-web-kit",
+ "objc2 0.6.3",
+ "objc2-ui-kit 0.3.2",
+ "objc2-web-kit 0.3.2",
  "raw-window-handle",
  "serde",
  "serde_json",
@@ -7176,9 +7499,9 @@ dependencies = [
  "http",
  "jni",
  "log",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
@@ -7389,7 +7712,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -7415,6 +7740,18 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -7601,6 +7938,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -7610,12 +7959,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -7628,13 +7980,13 @@ dependencies = [
  "dirs",
  "libappindicator",
  "muda",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -7645,6 +7997,23 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
 
 [[package]]
 name = "typeid"
@@ -7843,6 +8212,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -8153,10 +8528,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c"
 dependencies = [
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
@@ -8724,7 +9099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728b7d4c8ec8d81cab295e0b5b8a4c263c0d41a785fb8f8c4df284e5411140a2"
 dependencies = [
  "base64 0.22.1",
- "block2",
+ "block2 0.6.2",
  "cookie",
  "crossbeam-channel",
  "dirs",
@@ -8739,12 +9114,12 @@ dependencies = [
  "kuchikiki",
  "libc",
  "ndk",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
- "objc2-ui-kit",
- "objc2-web-kit",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "objc2-web-kit 0.3.2",
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
@@ -9065,6 +9440,21 @@ name = "zmij"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7a1c0af6e5d8d1363f4994b7a091ccf963d8b694f7da5b0b9cceb82da2c0a6"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,11 +38,18 @@ sea-orm = { workspace = true }
 entity = { path = "entity" }
 migration = { path = "migration" }
 uuid = { version = "1", features = ["v7"] }
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["sync", "time", "macros"] }
+tokio-util = "0.7"
+dashmap = "6"
+sha2 = "0.10"
+serde_bytes = "0.11"
 tauri-plugin-store = "2.4.2"
 tauri-plugin-dialog = "2.6.0"
+tauri-plugin-mcp-bridge = "0.10"
 notify = { version = "8", features = [] }
 notify-debouncer-mini = "0.6"
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -18,6 +18,7 @@
     "dialog:default",
     "core:event:default",
     "core:event:allow-listen",
-    "core:event:allow-emit"
+    "core:event:allow-emit",
+    "mcp-bridge:default"
   ]
 }

--- a/src-tauri/src/device/mod.rs
+++ b/src-tauri/src/device/mod.rs
@@ -1,0 +1,130 @@
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+use swarm_p2p_core::libp2p::core::Multiaddr;
+use swarm_p2p_core::libp2p::PeerId;
+
+use crate::protocol::OsInfo;
+
+/// 运行时 peer 信息
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeerInfo {
+    pub peer_id: String,
+    pub hostname: String,
+    pub os: String,
+    pub platform: String,
+    pub arch: String,
+    pub is_connected: bool,
+    pub rtt_ms: Option<u64>,
+    pub connection_type: Option<String>,
+    #[serde(skip)]
+    pub addrs: Vec<Multiaddr>,
+}
+
+/// 管理运行时设备发现和连接状态
+pub struct DeviceManager {
+    peers: DashMap<PeerId, PeerInfo>,
+}
+
+impl DeviceManager {
+    pub fn new() -> Self {
+        Self {
+            peers: DashMap::new(),
+        }
+    }
+
+    /// 添加发现的 peers（来自 mDNS / DHT），不更新连接状态
+    pub fn add_peers(&self, peers: Vec<(PeerId, Multiaddr)>) {
+        for (peer_id, addr) in peers {
+            self.peers
+                .entry(peer_id)
+                .and_modify(|info| {
+                    if !info.addrs.contains(&addr) {
+                        info.addrs.push(addr.clone());
+                    }
+                })
+                .or_insert_with(|| PeerInfo {
+                    peer_id: peer_id.to_string(),
+                    hostname: String::new(),
+                    os: String::new(),
+                    platform: String::new(),
+                    arch: String::new(),
+                    is_connected: false,
+                    rtt_ms: None,
+                    connection_type: None,
+                    addrs: vec![addr],
+                });
+        }
+    }
+
+    /// 标记 peer 已连接
+    pub fn set_connected(&self, peer_id: &PeerId) {
+        if let Some(mut info) = self.peers.get_mut(peer_id) {
+            info.is_connected = true;
+        } else {
+            self.peers.insert(
+                *peer_id,
+                PeerInfo {
+                    peer_id: peer_id.to_string(),
+                    hostname: String::new(),
+                    os: String::new(),
+                    platform: String::new(),
+                    arch: String::new(),
+                    is_connected: true,
+                    rtt_ms: None,
+                    connection_type: None,
+                    addrs: Vec::new(),
+                },
+            );
+        }
+    }
+
+    /// 标记 peer 已断开
+    pub fn set_disconnected(&self, peer_id: &PeerId) {
+        if let Some(mut info) = self.peers.get_mut(peer_id) {
+            info.is_connected = false;
+            info.rtt_ms = None;
+        }
+    }
+
+    /// 设置 peer 的 agent_version，解析 OsInfo。
+    /// 返回 true 如果是 SwarmNote 设备，false 否则（非 SwarmNote 设备会被移除）。
+    pub fn set_agent_version(&self, peer_id: &PeerId, agent_version: &str) -> bool {
+        match OsInfo::from_agent_version(agent_version) {
+            Some(os_info) => {
+                if let Some(mut info) = self.peers.get_mut(peer_id) {
+                    info.hostname = os_info.hostname;
+                    info.os = os_info.os;
+                    info.platform = os_info.platform;
+                    info.arch = os_info.arch;
+                }
+                true
+            }
+            None => {
+                // 非 SwarmNote 设备，移除
+                self.peers.remove(peer_id);
+                false
+            }
+        }
+    }
+
+    /// 更新 RTT
+    pub fn update_rtt(&self, peer_id: &PeerId, rtt_ms: u64) {
+        if let Some(mut info) = self.peers.get_mut(peer_id) {
+            info.rtt_ms = Some(rtt_ms);
+        }
+    }
+
+    /// 获取所有已连接的 SwarmNote peers
+    pub fn get_connected_peers(&self) -> Vec<PeerInfo> {
+        self.peers
+            .iter()
+            .filter(|entry| entry.value().is_connected)
+            .map(|entry| entry.value().clone())
+            .collect()
+    }
+
+    /// 获取指定 peer 的信息
+    pub fn get_peer(&self, peer_id: &PeerId) -> Option<PeerInfo> {
+        self.peers.get(peer_id).map(|entry| entry.value().clone())
+    }
+}

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -24,6 +24,8 @@ pub enum AppError {
     NameConflict(String),
     #[error("No workspace open")]
     NoWorkspaceOpen,
+    #[error("Network error: {0}")]
+    Network(String),
 }
 
 /// 结构化序列化：为前端提供 `{ kind: "...", message: "..." }` 格式。
@@ -45,6 +47,7 @@ impl Serialize for AppError {
             AppError::PathTraversal(msg) => ("PathTraversal", msg.clone()),
             AppError::NameConflict(msg) => ("NameConflict", msg.clone()),
             AppError::NoWorkspaceOpen => ("NoWorkspaceOpen", self.to_string()),
+            AppError::Network(msg) => ("Network", msg.clone()),
         };
 
         state.serialize_field("kind", kind)?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,16 +1,33 @@
 mod config;
+mod device;
 mod document;
 pub mod error;
 mod fs;
 mod identity;
+mod network;
+mod protocol;
 mod workspace;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "swarmnote_lib=info,swarm_p2p_core=info".into()),
+        )
+        .init();
+
+    let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_store::Builder::new().build())
-        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_dialog::init());
+
+    #[cfg(debug_assertions)]
+    {
+        builder = builder.plugin(tauri_plugin_mcp_bridge::init());
+    }
+
+    builder
         .invoke_handler(tauri::generate_handler![
             // 设备身份
             identity::commands::get_device_info,
@@ -33,6 +50,10 @@ pub fn run() {
             fs::commands::fs_delete_file,
             fs::commands::fs_delete_dir,
             fs::commands::fs_rename,
+            // P2P 网络
+            network::commands::start_p2p_node,
+            network::commands::stop_p2p_node,
+            network::commands::get_connected_peers,
         ])
         .setup(|app| {
             use tauri::Manager;
@@ -40,6 +61,10 @@ pub fn run() {
             identity::init(app.handle())?;
             workspace::init(app.handle())?;
             app.manage(fs::watcher::FsWatcherState::new());
+
+            // P2P 网络状态（初始为 None，通过 start_p2p_node 启动）
+            let net_state: network::NetManagerState = tokio::sync::Mutex::new(None);
+            app.manage(net_state);
 
             #[cfg(not(target_os = "macos"))]
             {

--- a/src-tauri/src/network/commands.rs
+++ b/src-tauri/src/network/commands.rs
@@ -1,0 +1,110 @@
+use tauri::{AppHandle, State};
+use tracing::info;
+
+use crate::device::PeerInfo;
+use crate::error::AppResult;
+use crate::identity::IdentityState;
+use crate::protocol::{AppRequest, AppResponse, OsInfo};
+
+use super::config::create_node_config;
+use super::event_loop::spawn_event_loop;
+use super::online::AppNetClient;
+use super::{NetManager, NetManagerState};
+
+/// 启动 P2P 节点
+#[tauri::command]
+pub async fn start_p2p_node(
+    app: AppHandle,
+    identity: State<'_, IdentityState>,
+    net_state: State<'_, NetManagerState>,
+) -> AppResult<()> {
+    let mut guard = net_state.lock().await;
+    if guard.is_some() {
+        return Err(crate::error::AppError::Network(
+            "P2P node is already running".to_string(),
+        ));
+    }
+
+    // 从 IdentityState 克隆 keypair
+    let keypair = identity.keypair.clone();
+    let peer_id = keypair.public().to_peer_id();
+
+    // 构建 agent_version
+    let os_info = OsInfo::default();
+    let agent_version = os_info.to_agent_version(env!("CARGO_PKG_VERSION"));
+
+    // 创建节点配置
+    let config = create_node_config(agent_version);
+
+    // 启动 P2P 节点
+    let (client, receiver): (AppNetClient, _) =
+        swarm_p2p_core::start::<AppRequest, AppResponse>(keypair, config)
+            .map_err(|e| crate::error::AppError::Network(format!("Failed to start P2P: {e}")))?;
+
+    // 创建 NetManager
+    let net_manager = NetManager::new(client.clone(), peer_id);
+    let cancel_token = net_manager.cancel_token();
+
+    // 启动事件循环
+    spawn_event_loop(
+        receiver,
+        app.clone(),
+        net_manager.device_manager.clone(),
+        cancel_token.clone(),
+    );
+
+    // 在线宣告 + DHT bootstrap + 已配对设备重连（后台任务）
+    let announcer = net_manager.online_announcer.clone();
+    let bootstrap_client = client.clone();
+
+    tokio::spawn(async move {
+        // 先 announce online
+        if let Err(e) = announcer.announce_online().await {
+            tracing::warn!("Failed to announce online: {e}");
+        }
+
+        // DHT bootstrap
+        match bootstrap_client.bootstrap().await {
+            Ok(_) => info!("DHT bootstrap completed"),
+            Err(e) => tracing::warn!("DHT bootstrap failed: {e}"),
+        }
+
+        // TODO(#26): 从 SQLite 读取已配对设备并 check_paired_online
+        // let paired_peer_ids = read_paired_devices_from_db().await;
+        // announcer.check_paired_online(paired_peer_ids).await;
+    });
+
+    // 启动周期续期
+    net_manager
+        .online_announcer
+        .clone()
+        .spawn_renewal_task(cancel_token);
+
+    *guard = Some(net_manager);
+
+    info!("P2P node started, PeerId: {peer_id}");
+    Ok(())
+}
+
+/// 停止 P2P 节点
+#[tauri::command]
+pub async fn stop_p2p_node(net_state: State<'_, NetManagerState>) -> AppResult<()> {
+    let mut guard = net_state.lock().await;
+    if let Some(manager) = guard.take() {
+        manager.shutdown().await;
+        info!("P2P node stopped");
+    }
+    Ok(())
+}
+
+/// 获取已连接的 peers 列表
+#[tauri::command]
+pub async fn get_connected_peers(
+    net_state: State<'_, NetManagerState>,
+) -> AppResult<Vec<PeerInfo>> {
+    let guard = net_state.lock().await;
+    match guard.as_ref() {
+        Some(manager) => Ok(manager.device_manager.get_connected_peers()),
+        None => Ok(Vec::new()),
+    }
+}

--- a/src-tauri/src/network/config.rs
+++ b/src-tauri/src/network/config.rs
@@ -1,0 +1,44 @@
+use std::time::Duration;
+
+use swarm_p2p_core::libp2p::core::Multiaddr;
+use swarm_p2p_core::libp2p::PeerId;
+use swarm_p2p_core::NodeConfig;
+
+/// SwarmDrop 的公共 bootstrap 节点（DHT key 有命名空间隔离，不会冲突）
+const BOOTSTRAP_NODES: &[&str] = &[
+    "/ip4/47.115.172.218/tcp/4001/p2p/12D3KooWCq8xgrSap7VZZHpW7EYXw8zFmNEgru9D7cGHGW3bMASX",
+    "/ip4/47.115.172.218/udp/4001/quic-v1/p2p/12D3KooWCq8xgrSap7VZZHpW7EYXw8zFmNEgru9D7cGHGW3bMASX",
+];
+
+/// 创建 P2P 节点配置
+pub fn create_node_config(agent_version: String) -> NodeConfig {
+    let bootstrap_peers = parse_bootstrap_nodes(BOOTSTRAP_NODES);
+
+    NodeConfig::new("/swarmnote/1.0.0", agent_version)
+        .with_mdns(true)
+        .with_relay_client(true)
+        .with_dcutr(true)
+        .with_autonat(true)
+        .with_gossipsub(true)
+        .with_req_resp_protocol("/swarmnote/req/1.0.0")
+        .with_req_resp_timeout(Duration::from_secs(180))
+        .with_bootstrap_peers(bootstrap_peers)
+}
+
+fn parse_bootstrap_nodes(nodes: &[&str]) -> Vec<(PeerId, Multiaddr)> {
+    nodes
+        .iter()
+        .filter_map(|s| {
+            let addr: Multiaddr = s.parse().ok()?;
+            // 从 multiaddr 提取 PeerId（最后一个 /p2p/<peer_id> 段）
+            let peer_id = addr.iter().find_map(|proto| {
+                if let swarm_p2p_core::libp2p::core::multiaddr::Protocol::P2p(peer_id) = proto {
+                    Some(peer_id)
+                } else {
+                    None
+                }
+            })?;
+            Some((peer_id, addr))
+        })
+        .collect()
+}

--- a/src-tauri/src/network/dht_key.rs
+++ b/src-tauri/src/network/dht_key.rs
@@ -1,0 +1,49 @@
+use sha2::{Digest, Sha256};
+use swarm_p2p_core::libp2p::kad::RecordKey;
+
+const NS_ONLINE: &[u8] = b"/swarmnote/online/";
+const NS_SHARE_CODE: &[u8] = b"/swarmnote/share-code/";
+
+/// 生成带命名空间的 DHT key: SHA256(namespace || id)
+fn dht_key(namespace: &[u8], id: &[u8]) -> RecordKey {
+    Sha256::digest([namespace, id].concat()).to_vec().into()
+}
+
+/// 在线宣告的 DHT key
+pub fn online_key(peer_id_bytes: &[u8]) -> RecordKey {
+    dht_key(NS_ONLINE, peer_id_bytes)
+}
+
+/// 配对码的 DHT key（供 #26 使用）
+#[allow(dead_code)]
+pub fn share_code_key(code: &str) -> RecordKey {
+    dht_key(NS_SHARE_CODE, code.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn online_key_deterministic() {
+        let peer_bytes = b"test-peer-id";
+        let key1 = online_key(peer_bytes);
+        let key2 = online_key(peer_bytes);
+        assert_eq!(key1, key2);
+    }
+
+    #[test]
+    fn different_peers_different_keys() {
+        let key1 = online_key(b"peer-1");
+        let key2 = online_key(b"peer-2");
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn different_namespaces_different_keys() {
+        let data = b"same-data";
+        let online = online_key(data);
+        let code = share_code_key("same-data");
+        assert_ne!(online, code);
+    }
+}

--- a/src-tauri/src/network/event_loop.rs
+++ b/src-tauri/src/network/event_loop.rs
@@ -1,0 +1,150 @@
+use std::sync::Arc;
+
+use swarm_p2p_core::event::NodeEvent;
+use swarm_p2p_core::EventReceiver;
+use tauri::{AppHandle, Emitter};
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use crate::device::DeviceManager;
+use crate::protocol::AppRequest;
+
+/// Tauri 事件名常量
+pub mod events {
+    pub const PEER_CONNECTED: &str = "peer-connected";
+    pub const PEER_DISCONNECTED: &str = "peer-disconnected";
+    pub const NETWORK_STATUS_CHANGED: &str = "network-status-changed";
+}
+
+/// 启动事件循环，持续读取 NodeEvent 并分发到 DeviceManager + Tauri 事件
+pub fn spawn_event_loop(
+    mut receiver: EventReceiver<AppRequest>,
+    app: AppHandle,
+    device_manager: Arc<DeviceManager>,
+    cancel_token: CancellationToken,
+) {
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = cancel_token.cancelled() => {
+                    info!("Event loop cancelled");
+                    break;
+                }
+                event = receiver.recv() => {
+                    match event {
+                        Some(event) => handle_event(event, &app, &device_manager),
+                        None => {
+                            info!("Event receiver closed, exiting event loop");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+fn handle_event(event: NodeEvent<AppRequest>, app: &AppHandle, device_manager: &DeviceManager) {
+    match event {
+        NodeEvent::Listening { addr } => {
+            info!("Listening on {addr}");
+        }
+
+        NodeEvent::PeersDiscovered { peers } => {
+            info!("Discovered {} peer(s)", peers.len());
+            device_manager.add_peers(peers);
+        }
+
+        NodeEvent::PeerConnected { peer_id } => {
+            info!("Peer connected: {peer_id}");
+            device_manager.set_connected(&peer_id);
+            if let Some(peer_info) = device_manager.get_peer(&peer_id) {
+                let _ = app.emit(events::PEER_CONNECTED, &peer_info);
+            }
+        }
+
+        NodeEvent::PeerDisconnected { peer_id } => {
+            info!("Peer disconnected: {peer_id}");
+            device_manager.set_disconnected(&peer_id);
+            let _ = app.emit(events::PEER_DISCONNECTED, peer_id.to_string());
+        }
+
+        NodeEvent::IdentifyReceived {
+            peer_id,
+            agent_version,
+            ..
+        } => {
+            let is_swarmnote = device_manager.set_agent_version(&peer_id, &agent_version);
+            if is_swarmnote {
+                info!("Identified SwarmNote peer: {peer_id} ({agent_version})");
+                if let Some(peer_info) = device_manager.get_peer(&peer_id) {
+                    let _ = app.emit(events::PEER_CONNECTED, &peer_info);
+                }
+            }
+        }
+
+        NodeEvent::PingSuccess { peer_id, rtt_ms } => {
+            device_manager.update_rtt(&peer_id, rtt_ms);
+        }
+
+        NodeEvent::NatStatusChanged {
+            status,
+            public_addr,
+        } => {
+            info!("NAT status changed: {status:?}, public_addr: {public_addr:?}");
+            let payload = serde_json::json!({
+                "natStatus": format!("{status:?}"),
+                "publicAddr": public_addr.map(|a| a.to_string()),
+            });
+            let _ = app.emit(events::NETWORK_STATUS_CHANGED, payload);
+        }
+
+        NodeEvent::HolePunchSucceeded { peer_id } => {
+            info!("Hole punch succeeded with {peer_id}");
+        }
+
+        NodeEvent::HolePunchFailed { peer_id, error } => {
+            warn!("Hole punch failed with {peer_id}: {error}");
+        }
+
+        NodeEvent::RelayReservationAccepted {
+            relay_peer_id,
+            renewal,
+        } => {
+            info!(
+                "Relay reservation {} by {relay_peer_id}",
+                if renewal { "renewed" } else { "accepted" }
+            );
+        }
+
+        NodeEvent::InboundRequest {
+            peer_id,
+            pending_id,
+            request,
+        } => {
+            // 暂不处理请求，留给 #26 (pairing) 和 #28 (sync)
+            match &request {
+                AppRequest::Pairing(_) => {
+                    warn!("Received pairing request from {peer_id} (pending_id={pending_id}), but pairing handler not yet implemented");
+                }
+                AppRequest::Sync(_) => {
+                    warn!("Received sync request from {peer_id} (pending_id={pending_id}), but sync handler not yet implemented");
+                }
+            }
+        }
+
+        NodeEvent::GossipMessage { source, topic, .. } => {
+            info!(
+                "GossipSub message from {source:?} on topic {topic} (handler not yet implemented)"
+            );
+        }
+
+        NodeEvent::GossipSubscribed { peer_id, topic } => {
+            info!("Peer {peer_id} subscribed to topic {topic}");
+        }
+
+        NodeEvent::GossipUnsubscribed { peer_id, topic } => {
+            info!("Peer {peer_id} unsubscribed from topic {topic}");
+        }
+    }
+}

--- a/src-tauri/src/network/mod.rs
+++ b/src-tauri/src/network/mod.rs
@@ -1,0 +1,56 @@
+pub mod commands;
+pub mod config;
+pub mod dht_key;
+pub mod event_loop;
+pub mod online;
+
+use std::sync::Arc;
+
+use swarm_p2p_core::libp2p::PeerId;
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
+
+use crate::device::DeviceManager;
+
+use self::online::{AppNetClient, OnlineAnnouncer};
+
+/// 网络管理器：持有 P2P 节点所有运行时状态
+pub struct NetManager {
+    /// 供 #26 pairing / #28 sync 使用
+    #[allow(dead_code)]
+    pub client: AppNetClient,
+    pub device_manager: Arc<DeviceManager>,
+    pub online_announcer: Arc<OnlineAnnouncer>,
+    cancel_token: CancellationToken,
+}
+
+impl NetManager {
+    pub fn new(client: AppNetClient, peer_id: PeerId) -> Self {
+        let device_manager = Arc::new(DeviceManager::new());
+        let online_announcer = Arc::new(OnlineAnnouncer::new(client.clone(), peer_id));
+        let cancel_token = CancellationToken::new();
+
+        Self {
+            client,
+            device_manager,
+            online_announcer,
+            cancel_token,
+        }
+    }
+
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel_token.clone()
+    }
+
+    /// 优雅关闭：通知 DHT 下线 → 取消后台任务
+    pub async fn shutdown(&self) {
+        // 尝试 announce_offline，但不阻塞关闭流程
+        if let Err(e) = self.online_announcer.announce_offline().await {
+            warn!("Failed to announce offline: {e}");
+        }
+        self.cancel_token.cancel();
+    }
+}
+
+/// NetManager 的 Tauri State 类型
+pub type NetManagerState = tokio::sync::Mutex<Option<NetManager>>;

--- a/src-tauri/src/network/online.rs
+++ b/src-tauri/src/network/online.rs
@@ -1,0 +1,165 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use swarm_p2p_core::libp2p::core::Multiaddr;
+use swarm_p2p_core::libp2p::kad::Record;
+use swarm_p2p_core::libp2p::PeerId;
+use swarm_p2p_core::NetClient;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use crate::protocol::{AppRequest, AppResponse, OsInfo};
+
+use super::dht_key;
+
+/// DHT 在线宣告记录
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OnlineRecord {
+    #[serde(flatten)]
+    pub os_info: OsInfo,
+    #[serde(default)]
+    pub listen_addrs: Vec<Multiaddr>,
+    pub timestamp: i64,
+}
+
+/// DHT 在线宣告 TTL（秒）
+const ONLINE_TTL_SECS: u64 = 300;
+/// 续期间隔（秒），需小于 TTL
+const RENEWAL_INTERVAL_SECS: u64 = 240;
+
+pub type AppNetClient = NetClient<AppRequest, AppResponse>;
+
+/// 管理 DHT 在线宣告：发布、续期、移除、已配对设备重连
+pub struct OnlineAnnouncer {
+    client: AppNetClient,
+    peer_id: PeerId,
+}
+
+impl OnlineAnnouncer {
+    pub fn new(client: AppNetClient, peer_id: PeerId) -> Self {
+        Self { client, peer_id }
+    }
+
+    /// 发布在线宣告到 DHT
+    pub async fn announce_online(&self) -> Result<(), String> {
+        let addrs = self
+            .client
+            .get_addrs()
+            .await
+            .map_err(|e| format!("get_addrs: {e}"))?;
+
+        let record_data = OnlineRecord {
+            os_info: OsInfo::default(),
+            listen_addrs: addrs,
+            timestamp: chrono::Utc::now().timestamp(),
+        };
+
+        let key = dht_key::online_key(&self.peer_id.to_bytes());
+        let value = serde_json::to_vec(&record_data).map_err(|e| format!("serialize: {e}"))?;
+
+        let record = Record {
+            key,
+            value,
+            publisher: Some(self.peer_id),
+            expires: Some(
+                std::time::Instant::now() + std::time::Duration::from_secs(ONLINE_TTL_SECS),
+            ),
+        };
+
+        self.client
+            .put_record(record)
+            .await
+            .map_err(|e| format!("put_record: {e}"))?;
+
+        info!("Published online announcement to DHT");
+        Ok(())
+    }
+
+    /// 从 DHT 移除在线宣告
+    pub async fn announce_offline(&self) -> Result<(), String> {
+        let key = dht_key::online_key(&self.peer_id.to_bytes());
+        self.client
+            .remove_record(key)
+            .await
+            .map_err(|e| format!("remove_record: {e}"))?;
+        info!("Removed online announcement from DHT");
+        Ok(())
+    }
+
+    /// 查询已配对设备的在线状态并主动拨号重连（供 #26 调用）
+    #[allow(dead_code)]
+    pub async fn check_paired_online(&self, paired_peer_ids: Vec<PeerId>) {
+        if paired_peer_ids.is_empty() {
+            return;
+        }
+
+        info!(
+            "Checking online status for {} paired devices",
+            paired_peer_ids.len()
+        );
+
+        for peer_id in paired_peer_ids {
+            let key = dht_key::online_key(&peer_id.to_bytes());
+            match self.client.get_record(key).await {
+                Ok(result) => {
+                    let record = result.record;
+                    // 跳过已过期记录
+                    if record
+                        .expires
+                        .is_some_and(|e| e < std::time::Instant::now())
+                    {
+                        continue;
+                    }
+
+                    if let Ok(online_record) = serde_json::from_slice::<OnlineRecord>(&record.value)
+                    {
+                        if online_record.listen_addrs.is_empty() {
+                            continue;
+                        }
+                        if let Err(e) = self
+                            .client
+                            .add_peer_addrs(peer_id, online_record.listen_addrs)
+                            .await
+                        {
+                            warn!("Failed to register addrs for {peer_id}: {e}");
+                            continue;
+                        }
+                        if let Err(e) = self.client.dial(peer_id).await {
+                            warn!("Failed to dial paired device {peer_id}: {e}");
+                        } else {
+                            info!("Initiated reconnection to paired device {peer_id}");
+                        }
+                    }
+                }
+                Err(_) => {
+                    // 设备离线或 DHT 查询失败，正常现象
+                }
+            }
+        }
+    }
+
+    /// 启动周期续期后台任务
+    pub fn spawn_renewal_task(self: Arc<Self>, cancel_token: CancellationToken) {
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(RENEWAL_INTERVAL_SECS));
+            // 跳过首次 tick（启动时已经 announce 了）
+            interval.tick().await;
+
+            loop {
+                tokio::select! {
+                    _ = cancel_token.cancelled() => {
+                        info!("Online announcement renewal task cancelled");
+                        break;
+                    }
+                    _ = interval.tick() => {
+                        if let Err(e) = self.announce_online().await {
+                            warn!("Failed to renew online announcement: {e}");
+                        }
+                    }
+                }
+            }
+        });
+    }
+}

--- a/src-tauri/src/protocol/mod.rs
+++ b/src-tauri/src/protocol/mod.rs
@@ -1,0 +1,264 @@
+use serde::{Deserialize, Serialize};
+
+// ── OsInfo: 设备信息，通过 libp2p agent_version 交换 ──
+
+/// 设备操作系统信息，嵌入在 agent_version 字符串中通过 Identify 协议自动交换。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OsInfo {
+    pub hostname: String,
+    pub os: String,
+    pub platform: String,
+    pub arch: String,
+}
+
+impl OsInfo {
+    /// 编码为 agent_version 格式：`swarmnote/{version}; os={os}; platform={platform}; arch={arch}; host={hostname}`
+    pub fn to_agent_version(&self, version: &str) -> String {
+        format!(
+            "swarmnote/{}; os={}; platform={}; arch={}; host={}",
+            version, self.os, self.platform, self.arch, self.hostname
+        )
+    }
+
+    /// 从 agent_version 字符串解析 OsInfo。
+    /// 返回 None 如果格式不匹配（非 SwarmNote 设备）。
+    pub fn from_agent_version(agent_version: &str) -> Option<Self> {
+        if !agent_version.starts_with("swarmnote/") {
+            return None;
+        }
+
+        let mut hostname = String::new();
+        let mut os = String::new();
+        let mut platform = String::new();
+        let mut arch = String::new();
+
+        for part in agent_version.split(';').map(str::trim) {
+            if let Some(val) = part.strip_prefix("os=") {
+                os = val.to_string();
+            } else if let Some(val) = part.strip_prefix("platform=") {
+                platform = val.to_string();
+            } else if let Some(val) = part.strip_prefix("arch=") {
+                arch = val.to_string();
+            } else if let Some(val) = part.strip_prefix("host=") {
+                hostname = val.to_string();
+            }
+        }
+
+        Some(OsInfo {
+            hostname,
+            os,
+            platform,
+            arch,
+        })
+    }
+}
+
+impl Default for OsInfo {
+    fn default() -> Self {
+        Self {
+            hostname: hostname::get()
+                .map(|h| h.to_string_lossy().to_string())
+                .unwrap_or_default(),
+            os: std::env::consts::OS.to_string(),
+            platform: std::env::consts::FAMILY.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+        }
+    }
+}
+
+// ── 顶层协议消息 ──
+
+/// 顶层请求枚举，包装所有子协议。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum AppRequest {
+    Pairing(PairingRequest),
+    Sync(SyncRequest),
+}
+
+/// 顶层响应枚举，包装所有子协议。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum AppResponse {
+    Pairing(PairingResponse),
+    Sync(SyncResponse),
+}
+
+// ── 同步子协议 ──
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SyncRequest {
+    /// 发送本地 state vector，请求对方返回缺失的 updates
+    StateVector {
+        doc_id: String,
+        #[serde(with = "serde_bytes")]
+        sv: Vec<u8>,
+    },
+    /// 请求完整文档状态
+    FullSync { doc_id: String },
+    /// 查询对方拥有的文档列表
+    DocList,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SyncResponse {
+    /// 返回请求方缺失的 yjs updates
+    Updates {
+        doc_id: String,
+        #[serde(with = "serde_bytes")]
+        updates: Vec<u8>,
+    },
+    /// 返回文档元数据列表
+    DocList { docs: Vec<DocMeta> },
+}
+
+/// 文档元数据，用于 DocList 交换
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DocMeta {
+    pub doc_id: String,
+    pub title: String,
+    pub updated_at: i64,
+}
+
+// ── 配对子协议 ──
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PairingRequest {
+    pub os_info: OsInfo,
+    pub timestamp: i64,
+    pub method: PairingMethod,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum PairingMethod {
+    Code { code: String },
+    Direct,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status")]
+pub enum PairingResponse {
+    Success,
+    Refused { reason: PairingRefuseReason },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PairingRefuseReason {
+    UserRejected,
+    CodeExpired,
+    CodeInvalid,
+}
+
+// ── 测试 ──
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn os_info_agent_version_roundtrip() {
+        let info = OsInfo {
+            hostname: "MacBook-Pro".to_string(),
+            os: "macos".to_string(),
+            platform: "macos".to_string(),
+            arch: "aarch64".to_string(),
+        };
+
+        let agent = info.to_agent_version("0.2.0");
+        assert_eq!(
+            agent,
+            "swarmnote/0.2.0; os=macos; platform=macos; arch=aarch64; host=MacBook-Pro"
+        );
+
+        let parsed = OsInfo::from_agent_version(&agent).unwrap();
+        assert_eq!(parsed, info);
+    }
+
+    #[test]
+    fn os_info_from_agent_version_non_swarmnote() {
+        assert!(OsInfo::from_agent_version("swarmdrop/0.4.0; os=windows").is_none());
+        assert!(OsInfo::from_agent_version("some-other-app/1.0").is_none());
+    }
+
+    #[test]
+    fn os_info_default() {
+        let info = OsInfo::default();
+        assert!(!info.os.is_empty());
+        assert!(!info.arch.is_empty());
+    }
+
+    #[test]
+    fn app_request_cbor_roundtrip() {
+        let requests = vec![
+            AppRequest::Sync(SyncRequest::DocList),
+            AppRequest::Sync(SyncRequest::FullSync {
+                doc_id: "doc-123".to_string(),
+            }),
+            AppRequest::Sync(SyncRequest::StateVector {
+                doc_id: "doc-456".to_string(),
+                sv: vec![1, 2, 3, 4],
+            }),
+            AppRequest::Pairing(PairingRequest {
+                os_info: OsInfo::default(),
+                timestamp: 1234567890,
+                method: PairingMethod::Code {
+                    code: "123456".to_string(),
+                },
+            }),
+            AppRequest::Pairing(PairingRequest {
+                os_info: OsInfo::default(),
+                timestamp: 1234567890,
+                method: PairingMethod::Direct,
+            }),
+        ];
+
+        for req in requests {
+            let json = serde_json::to_string(&req).unwrap();
+            let restored: AppRequest = serde_json::from_str(&json).unwrap();
+            // Verify it round-trips without panic
+            let json2 = serde_json::to_string(&restored).unwrap();
+            assert_eq!(json, json2);
+        }
+    }
+
+    #[test]
+    fn app_response_cbor_roundtrip() {
+        let responses = vec![
+            AppResponse::Sync(SyncResponse::DocList {
+                docs: vec![DocMeta {
+                    doc_id: "doc-1".to_string(),
+                    title: "Test Note".to_string(),
+                    updated_at: 1234567890,
+                }],
+            }),
+            AppResponse::Sync(SyncResponse::Updates {
+                doc_id: "doc-1".to_string(),
+                updates: vec![10, 20, 30],
+            }),
+            AppResponse::Pairing(PairingResponse::Success),
+            AppResponse::Pairing(PairingResponse::Refused {
+                reason: PairingRefuseReason::CodeExpired,
+            }),
+        ];
+
+        for resp in responses {
+            let json = serde_json::to_string(&resp).unwrap();
+            let restored: AppResponse = serde_json::from_str(&json).unwrap();
+            let json2 = serde_json::to_string(&restored).unwrap();
+            assert_eq!(json, json2);
+        }
+    }
+
+    #[test]
+    fn pairing_method_serde_tag() {
+        let method = PairingMethod::Code {
+            code: "123456".to_string(),
+        };
+        let json = serde_json::to_string(&method).unwrap();
+        assert!(json.contains("\"type\":\"Code\""));
+        assert!(json.contains("\"code\":\"123456\""));
+
+        let direct = PairingMethod::Direct;
+        let json = serde_json::to_string(&direct).unwrap();
+        assert!(json.contains("\"type\":\"Direct\""));
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,11 +10,12 @@
     "frontendDist": "../dist"
   },
   "app": {
+    "withGlobalTauri": true,
     "windows": [
       {
         "title": "SwarmNote",
-        "width": 1440,
-        "height": 900,
+        "width": 800,
+        "height": 600,
         "minWidth": 800,
         "minHeight": 600,
         "decorations": true,

--- a/src/stores/networkStore.ts
+++ b/src/stores/networkStore.ts
@@ -1,0 +1,97 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { create } from "zustand";
+
+// ── Types ──
+
+export interface PeerInfo {
+  peer_id: string;
+  hostname: string;
+  os: string;
+  platform: string;
+  arch: string;
+  is_connected: boolean;
+  rtt_ms: number | null;
+  connection_type: string | null;
+}
+
+interface NetworkStatus {
+  natStatus: string | null;
+  publicAddr: string | null;
+}
+
+interface NetworkState {
+  isNodeRunning: boolean;
+  connectedPeers: PeerInfo[];
+  natStatus: string | null;
+}
+
+interface NetworkActions {
+  startNode: () => Promise<void>;
+  stopNode: () => Promise<void>;
+  refreshPeers: () => Promise<void>;
+}
+
+// ── Store ──
+
+export const useNetworkStore = create<NetworkState & NetworkActions>()((set) => ({
+  isNodeRunning: false,
+  connectedPeers: [],
+  natStatus: null,
+
+  startNode: async () => {
+    await invoke("start_p2p_node");
+    set({ isNodeRunning: true });
+  },
+
+  stopNode: async () => {
+    await invoke("stop_p2p_node");
+    set({ isNodeRunning: false, connectedPeers: [], natStatus: null });
+  },
+
+  refreshPeers: async () => {
+    const peers = await invoke<PeerInfo[]>("get_connected_peers");
+    set({ connectedPeers: peers });
+  },
+}));
+
+// ── Tauri Event Listeners ──
+
+let unlisteners: UnlistenFn[] = [];
+
+export async function setupNetworkListeners() {
+  // 避免重复监听
+  await cleanupNetworkListeners();
+
+  const u1 = await listen<PeerInfo>("peer-connected", (event) => {
+    const peer = event.payload;
+    useNetworkStore.setState((state) => {
+      const existing = state.connectedPeers.findIndex((p) => p.peer_id === peer.peer_id);
+      const peers =
+        existing >= 0
+          ? state.connectedPeers.map((p, i) => (i === existing ? peer : p))
+          : [...state.connectedPeers, peer];
+      return { connectedPeers: peers };
+    });
+  });
+
+  const u2 = await listen<string>("peer-disconnected", (event) => {
+    const peerId = event.payload;
+    useNetworkStore.setState((state) => ({
+      connectedPeers: state.connectedPeers.filter((p) => p.peer_id !== peerId),
+    }));
+  });
+
+  const u3 = await listen<NetworkStatus>("network-status-changed", (event) => {
+    useNetworkStore.setState({ natStatus: event.payload.natStatus });
+  });
+
+  unlisteners = [u1, u2, u3];
+}
+
+export async function cleanupNetworkListeners() {
+  for (const unlisten of unlisteners) {
+    unlisten();
+  }
+  unlisteners = [];
+}


### PR DESCRIPTION
- Define protocol messages: AppRequest/AppResponse top-level envelope with Sync (StateVector/FullSync/DocList) and Pairing sub-protocols
- Implement DeviceManager with DashMap for runtime peer tracking, filtering non-SwarmNote devices via agent_version prefix
- Add DHT online announcement with 300s TTL and 240s periodic renewal, plus paired device reconnection via check_paired_online()
- Build NetManager with event loop bridging NodeEvent to Tauri events (peer-connected, peer-disconnected, network-status-changed)
- Expose Tauri commands: start_p2p_node, stop_p2p_node, get_connected_peers
- Create frontend networkStore (Zustand) with Tauri event listeners
- Initialize tracing-subscriber for Rust backend logging