### PR TITLE
feat(storage): implement markdown persistence with media support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -686,6 +686,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,6 +1118,12 @@ name = "const-str"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -2664,6 +2684,12 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
 
 [[package]]
 name = "httparse"
@@ -7074,6 +7100,7 @@ dependencies = [
 name = "swarmnote"
 version = "0.1.0"
 dependencies = [
+ "blake3",
  "chrono",
  "dashmap",
  "directories",
@@ -7280,6 +7307,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "image",
  "jni",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon", "image-png"] }
+tauri = { version = "2", features = ["tray-icon", "image-png", "protocol-asset"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -43,6 +43,7 @@ tokio-util = "0.7"
 dashmap = "6"
 sha2 = "0.10"
 serde_bytes = "0.11"
+blake3 = "1"
 tauri-plugin-store = "2.4.2"
 tauri-plugin-dialog = "2.6.0"
 tauri-plugin-notification = "2"

--- a/src-tauri/src/document/commands.rs
+++ b/src-tauri/src/document/commands.rs
@@ -17,6 +17,7 @@ pub struct UpsertDocumentInput {
     pub folder_id: Option<String>,
     pub title: String,
     pub rel_path: String,
+    pub file_hash: Option<String>,
 }
 
 #[tauri::command]
@@ -49,6 +50,9 @@ pub async fn db_upsert_document(
             model.title = Set(input.title);
             model.folder_id = Set(input.folder_id);
             model.rel_path = Set(input.rel_path);
+            if let Some(hash) = input.file_hash {
+                model.file_hash = Set(Some(hash.into_bytes()));
+            }
             model.updated_at = Set(now);
             return Ok(model.update(db).await?);
         }
@@ -61,7 +65,7 @@ pub async fn db_upsert_document(
         folder_id: Set(input.folder_id),
         title: Set(input.title),
         rel_path: Set(input.rel_path),
-        file_hash: Set(None),
+        file_hash: Set(input.file_hash.map(|h| h.into_bytes())),
         yjs_state: Set(None),
         state_vector: Set(None),
         created_by: Set(identity.peer_id()?),

--- a/src-tauri/src/fs/commands.rs
+++ b/src-tauri/src/fs/commands.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use tauri::State;
 
 use crate::error::{AppError, AppResult};
@@ -5,9 +6,108 @@ use crate::workspace::state::WorkspaceState;
 
 use super::FileTreeNode;
 
+#[derive(Debug, Serialize)]
+pub struct SaveDocumentResult {
+    /// blake3 hash hex string
+    pub file_hash: String,
+}
+
 /// 从 per-window 状态中获取指定窗口的工作区路径。
 async fn workspace_path_for(ws_state: &WorkspaceState, label: &str) -> Result<String, AppError> {
     ws_state.workspace_path_for(label).await
+}
+
+#[tauri::command]
+pub async fn load_document(
+    window: tauri::Window,
+    rel_path: String,
+    ws_state: State<'_, WorkspaceState>,
+) -> AppResult<String> {
+    let path = workspace_path_for(&ws_state, window.label()).await?;
+    let ws_path = std::path::PathBuf::from(&path);
+    tokio::task::spawn_blocking(move || {
+        super::crud::validate_rel_path(&ws_path, &rel_path)?;
+        let full_path = ws_path.join(&rel_path);
+        match std::fs::read_to_string(&full_path) {
+            Ok(content) => Ok(content),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+            Err(e) => Err(e.into()),
+        }
+    })
+    .await
+    .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))?
+}
+
+#[tauri::command]
+pub async fn save_document(
+    window: tauri::Window,
+    rel_path: String,
+    content: String,
+    ws_state: State<'_, WorkspaceState>,
+) -> AppResult<SaveDocumentResult> {
+    let path = workspace_path_for(&ws_state, window.label()).await?;
+    let ws_path = std::path::PathBuf::from(&path);
+    tokio::task::spawn_blocking(move || {
+        super::crud::validate_rel_path(&ws_path, &rel_path)?;
+        let full_path = ws_path.join(&rel_path);
+        std::fs::write(&full_path, &content)?;
+        let hash = blake3::hash(content.as_bytes());
+        Ok(SaveDocumentResult {
+            file_hash: hash.to_hex().to_string(),
+        })
+    })
+    .await
+    .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))?
+}
+
+#[tauri::command]
+pub async fn save_media(
+    window: tauri::Window,
+    rel_path: String,
+    file_name: String,
+    data: Vec<u8>,
+    ws_state: State<'_, WorkspaceState>,
+) -> AppResult<String> {
+    let path = workspace_path_for(&ws_state, window.label()).await?;
+    let ws_path = std::path::PathBuf::from(&path);
+    tokio::task::spawn_blocking(move || {
+        super::crud::validate_rel_path(&ws_path, &rel_path)?;
+        // Resource dir: "notes/my-note.md" → "notes/my-note/"
+        let rel = std::path::Path::new(&rel_path);
+        let resource_dir = ws_path.join(rel.with_extension(""));
+        std::fs::create_dir_all(&resource_dir)?;
+
+        // Resolve filename conflicts using existing resolve_conflict pattern
+        let target = resource_dir.join(&file_name);
+        let actual_path = if target.exists() {
+            let stem = std::path::Path::new(&file_name)
+                .file_stem()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            let ext = std::path::Path::new(&file_name)
+                .extension()
+                .map(|e| format!(".{}", e.to_string_lossy()))
+                .unwrap_or_default();
+            let mut n = 1u32;
+            loop {
+                let candidate = resource_dir.join(format!("{stem} {n}{ext}"));
+                if !candidate.exists() {
+                    break candidate;
+                }
+                n += 1;
+            }
+        } else {
+            target
+        };
+
+        std::fs::write(&actual_path, &data)?;
+
+        // Return absolute path (frontend will use convertFileSrc)
+        Ok(actual_path.to_string_lossy().replace('\\', "/"))
+    })
+    .await
+    .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))?
 }
 
 #[tauri::command]

--- a/src-tauri/src/fs/crud.rs
+++ b/src-tauri/src/fs/crud.rs
@@ -111,13 +111,25 @@ pub fn create_dir(workspace: &Path, parent_rel: &str, name: &str) -> Result<Stri
 }
 
 /// 删除文件。幂等操作 —— 文件不存在时也视为成功。
+///
+/// 对 `.md` 文件，同步删除同名资源目录（best-effort）。
 pub fn delete_file(workspace: &Path, rel_path: &str) -> Result<(), AppError> {
     let full = validate_rel_path(workspace, rel_path)?;
-    match std::fs::remove_file(full) {
-        Ok(()) => Ok(()),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(e.into()),
+    match std::fs::remove_file(&full) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e.into()),
     }
+
+    // Best-effort: delete resource directory for .md files (e.g. "note.md" → "note/")
+    if full.extension().and_then(|e| e.to_str()) == Some("md") {
+        let resource_dir = full.with_extension("");
+        if resource_dir.is_dir() {
+            let _ = std::fs::remove_dir_all(resource_dir);
+        }
+    }
+
+    Ok(())
 }
 
 /// 递归删除目录及其所有内容。
@@ -152,6 +164,15 @@ pub fn rename(workspace: &Path, rel_path: &str, new_name: &str) -> Result<String
     let new_path = parent.join(&target_name);
     if new_path.exists() {
         return Err(AppError::NameConflict(target_name));
+    }
+
+    // Best-effort: rename resource directory for .md files (e.g. "note/" → "diary/")
+    if full.is_file() && full.extension().and_then(|e| e.to_str()) == Some("md") {
+        let old_resource_dir = full.with_extension("");
+        if old_resource_dir.is_dir() {
+            let new_resource_dir = new_path.with_extension("");
+            let _ = std::fs::rename(&old_resource_dir, &new_resource_dir);
+        }
     }
 
     std::fs::rename(&full, &new_path)?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -55,6 +55,9 @@ pub fn run() {
             fs::commands::fs_delete_file,
             fs::commands::fs_delete_dir,
             fs::commands::fs_rename,
+            fs::commands::load_document,
+            fs::commands::save_document,
+            fs::commands::save_media,
             // P2P 网络
             network::commands::start_p2p_node,
             network::commands::stop_p2p_node,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,11 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["**"]
+      }
     }
   },
   "bundle": {

--- a/src/commands/document.ts
+++ b/src/commands/document.ts
@@ -20,6 +20,11 @@ export interface UpsertDocumentInput {
   folder_id?: string | null;
   title: string;
   rel_path: string;
+  file_hash?: string | null;
+}
+
+export interface SaveDocumentResult {
+  file_hash: string;
 }
 
 export async function getDocuments(workspaceId: string): Promise<DocumentModel[]> {
@@ -34,12 +39,21 @@ export async function deleteDocument(id: string): Promise<void> {
   return invoke("db_delete_document", { id });
 }
 
-// TODO(#6): Replace with Tauri invoke: invoke("load_document", { relPath })
 export async function loadDocumentContent(relPath: string): Promise<string> {
-  return localStorage.getItem(`swarmnote:doc:${relPath}`) ?? "";
+  return invoke<string>("load_document", { relPath });
 }
 
-// TODO(#6): Replace with Tauri invoke: invoke("save_document", { relPath, markdown })
-export async function saveDocumentContent(relPath: string, markdown: string): Promise<void> {
-  localStorage.setItem(`swarmnote:doc:${relPath}`, markdown);
+export async function saveDocumentContent(
+  relPath: string,
+  content: string,
+): Promise<SaveDocumentResult> {
+  return invoke<SaveDocumentResult>("save_document", { relPath, content });
+}
+
+export async function saveMedia(
+  relPath: string,
+  fileName: string,
+  data: number[],
+): Promise<string> {
+  return invoke<string>("save_media", { relPath, fileName, data });
 }

--- a/src/components/editor/EditorTitle.tsx
+++ b/src/components/editor/EditorTitle.tsx
@@ -5,7 +5,7 @@ import { useFileTreeStore } from "@/stores/fileTreeStore";
 export function EditorTitle() {
   const title = useEditorStore((s) => s.title);
   const relPath = useEditorStore((s) => s.relPath);
-  const updateTitle = useEditorStore((s) => s.updateTitle);
+  const updateRelPath = useEditorStore((s) => s.updateRelPath);
   const rename = useFileTreeStore((s) => s.rename);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -14,11 +14,11 @@ export function EditorTitle() {
     const newTitle = raw.toLowerCase().endsWith(".md") ? raw : `${raw}.md`;
     if (newTitle === title) return;
 
-    updateTitle(newTitle);
     if (relPath) {
-      await rename(relPath, newTitle);
+      const newRelPath = await rename(relPath, newTitle);
+      updateRelPath(newRelPath, newTitle);
     }
-  }, [title, relPath, updateTitle, rename]);
+  }, [title, relPath, updateRelPath, rename]);
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
@@ -30,7 +30,7 @@ export function EditorTitle() {
   return (
     <input
       ref={inputRef}
-      className="w-full border-none bg-transparent text-3xl font-bold text-foreground outline-none placeholder:text-muted-foreground"
+      className="w-full border-none bg-transparent text-2xl font-bold text-foreground outline-none placeholder:text-muted-foreground"
       placeholder="Untitled"
       defaultValue={title.replace(/\.md$/i, "")}
       onBlur={commitTitle}

--- a/src/components/editor/NoteEditor.tsx
+++ b/src/components/editor/NoteEditor.tsx
@@ -8,13 +8,15 @@ import {
 import { zh as bnZh } from "@blocknote/core/locales";
 import { useCreateBlockNote } from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/shadcn";
+import { convertFileSrc } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef } from "react";
+import { saveMedia } from "@/commands/document";
 import type { Locale } from "@/i18n";
 import { useEditorStore } from "@/stores/editorStore";
 import { useUIStore } from "@/stores/uiStore";
 import { EditorTitle } from "./EditorTitle";
 
-const { image: _, video: _v, audio: _a, file: _f, ...supportedBlockSpecs } = defaultBlockSpecs;
+const { audio: _a, file: _f, ...supportedBlockSpecs } = defaultBlockSpecs;
 
 const DEBOUNCE_MS = 1500;
 
@@ -40,15 +42,24 @@ export function NoteEditor() {
   const saveContentRef = useRef(saveContent);
   saveContentRef.current = saveContent;
 
+  const uploadFile = useCallback(async (file: File): Promise<string> => {
+    const relPath = useEditorStore.getState().relPath;
+    const buffer = await file.arrayBuffer();
+    const data = Array.from(new Uint8Array(buffer));
+    const absPath = await saveMedia(relPath, file.name, data);
+    return convertFileSrc(absPath);
+  }, []);
+
   const dictionary = bnDictMap[locale];
-  const editor = useCreateBlockNote({ schema, dictionary }, [locale]);
+  const editor = useCreateBlockNote({ schema, dictionary, uploadFile }, [locale]);
 
   // Load markdown content into editor on mount (one-time, non-reactive)
   useEffect(() => {
     const { markdown } = useEditorStore.getState();
-    if (!markdown) return;
     async function load() {
-      const blocks = await editor.tryParseMarkdownToBlocks(markdown);
+      const blocks = markdown
+        ? await editor.tryParseMarkdownToBlocks(markdown)
+        : [{ type: "paragraph" as const }];
       editor.replaceBlocks(editor.document, blocks);
     }
     load();

--- a/src/components/filetree/FileTree.tsx
+++ b/src/components/filetree/FileTree.tsx
@@ -146,7 +146,8 @@ export function FileTree({ width, height }: FileTreeProps) {
               onDelete={handleDelete}
               onRename={handleRename}
             >
-              <div>
+              {/* stopPropagation prevents outer ContextMenu from intercepting */}
+              <div role="none" onContextMenu={(e) => e.stopPropagation()}>
                 <FileTreeNodeRenderer {...props} />
               </div>
             </FileTreeContextMenu>

--- a/src/components/layout/EmptyState.tsx
+++ b/src/components/layout/EmptyState.tsx
@@ -5,7 +5,7 @@ import { modKey } from "@/lib/utils";
 import { useFileTreeStore } from "@/stores/fileTreeStore";
 
 export function EmptyState() {
-  const createFile = useFileTreeStore((s) => s.createFile);
+  const createAndOpenFile = useFileTreeStore((s) => s.createAndOpenFile);
 
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-4">
@@ -18,7 +18,10 @@ export function EmptyState() {
       <p className="text-sm text-muted-foreground">
         <Trans>创建你的第一篇笔记，开始记录想法</Trans>
       </p>
-      <Button className="gap-1.5 rounded-lg px-5 py-2.5" onClick={() => createFile("", "新建笔记")}>
+      <Button
+        className="gap-1.5 rounded-lg px-5 py-2.5"
+        onClick={() => createAndOpenFile("", "新建笔记")}
+      >
         <Plus className="h-4 w-4" />
         <Trans>新建笔记</Trans>
       </Button>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -41,7 +41,7 @@ export function Sidebar() {
   const setLocale = useUIStore((s) => s.setLocale);
   const workspace = useWorkspaceStore((s) => s.workspace);
   const rescan = useFileTreeStore((s) => s.rescan);
-  const createFile = useFileTreeStore((s) => s.createFile);
+  const createAndOpenFile = useFileTreeStore((s) => s.createAndOpenFile);
   const createDir = useFileTreeStore((s) => s.createDir);
 
   const pairedDevices = usePairingStore((s) => s.pairedDevices);
@@ -77,8 +77,8 @@ export function Sidebar() {
   }
 
   const handleCreateFile = useCallback(() => {
-    createFile("", t`新建笔记`);
-  }, [createFile, t]);
+    createAndOpenFile("", t`新建笔记`);
+  }, [createAndOpenFile, t]);
 
   const handleCreateDir = useCallback(() => {
     createDir("", t`新建文件夹`);

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -21,7 +21,7 @@ export function StatusBar() {
   return (
     <footer className="flex h-7 shrink-0 items-center justify-between border-t border-border bg-card px-4">
       <div className="flex items-center gap-3">
-        <span className="text-[11px] text-muted-foreground">
+        <span className="text-xs text-muted-foreground">
           {charCount.toLocaleString()} <Trans>字符</Trans>
         </span>
       </div>
@@ -29,14 +29,14 @@ export function StatusBar() {
         {isDirty ? (
           <>
             <Pencil className="h-3 w-3 text-muted-foreground" />
-            <span className="text-[11px] text-muted-foreground">
+            <span className="text-xs text-muted-foreground">
               <Trans>未保存</Trans>
             </span>
           </>
         ) : timeStr ? (
           <>
             <CircleCheck className="h-3 w-3 text-green-500" />
-            <span className="text-[11px] text-muted-foreground">
+            <span className="text-xs text-muted-foreground">
               <Trans>已保存</Trans> {timeStr}
             </span>
           </>

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { openSettingsWindow } from "@/commands/workspace";
 import { OPEN_COMMAND_PALETTE } from "@/components/layout/CommandPalette";
 import { isMac } from "@/lib/utils";
+import { useEditorStore } from "@/stores/editorStore";
 import { useFileTreeStore } from "@/stores/fileTreeStore";
 import { useUIStore } from "@/stores/uiStore";
 
@@ -26,11 +27,15 @@ export function useKeyboardShortcuts() {
           break;
         case "n":
           e.preventDefault();
-          useFileTreeStore.getState().createFile("", "新建笔记");
+          useFileTreeStore.getState().createAndOpenFile("", "新建笔记");
           break;
         case "p":
           e.preventDefault();
           document.dispatchEvent(new CustomEvent(OPEN_COMMAND_PALETTE));
+          break;
+        case "s":
+          e.preventDefault();
+          useEditorStore.getState().saveContent();
           break;
         case ",":
           e.preventDefault();

--- a/src/lib/markdownMedia.ts
+++ b/src/lib/markdownMedia.ts
@@ -1,0 +1,55 @@
+import { convertFileSrc } from "@tauri-apps/api/core";
+
+/**
+ * Pre-process markdown on load: convert relative media paths to asset URLs.
+ *
+ * Handles:
+ *  - `![alt](relative/path)` → `![alt](http://asset.localhost/...)`
+ *  - `<video src="relative/path">` → `<video src="http://asset.localhost/...">`
+ */
+export function relativePathToAssetUrl(markdown: string, workspacePath: string): string {
+  // Normalize workspace path separators
+  const wsPath = workspacePath.replace(/\\/g, "/");
+
+  // Match markdown image/video: ![...](url) — skip absolute URLs and data: URIs
+  const mdPattern = /(!\[[^\]]*]\()([^)]+)(\))/g;
+  let result = markdown.replace(mdPattern, (_match, prefix, url, suffix) => {
+    if (isAbsoluteOrSpecialUrl(url)) return `${prefix}${url}${suffix}`;
+    const absPath = `${wsPath}/${url}`;
+    return `${prefix}${convertFileSrc(absPath)}${suffix}`;
+  });
+
+  // Match HTML src attributes: src="..." — for <video>, <img> etc.
+  const htmlPattern = /(src=")([^"]+)(")/g;
+  result = result.replace(htmlPattern, (_match, prefix, url, suffix) => {
+    if (isAbsoluteOrSpecialUrl(url)) return `${prefix}${url}${suffix}`;
+    const absPath = `${wsPath}/${url}`;
+    return `${prefix}${convertFileSrc(absPath)}${suffix}`;
+  });
+
+  return result;
+}
+
+/**
+ * Post-process markdown on save: convert asset URLs back to relative paths.
+ */
+export function assetUrlToRelativePath(markdown: string, workspacePath: string): string {
+  // Normalize workspace path for matching
+  const wsPath = workspacePath.replace(/\\/g, "/");
+
+  // Build the expected asset URL prefix for this workspace
+  const wsAssetPrefix = convertFileSrc(`${wsPath}/`);
+
+  // Replace all occurrences of the workspace asset URL prefix with empty string (= relative path)
+  return markdown.split(wsAssetPrefix).join("");
+}
+
+function isAbsoluteOrSpecialUrl(url: string): boolean {
+  return (
+    url.startsWith("http://") ||
+    url.startsWith("https://") ||
+    url.startsWith("data:") ||
+    url.startsWith("blob:") ||
+    url.startsWith("/")
+  );
+}

--- a/src/stores/editorStore.ts
+++ b/src/stores/editorStore.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand";
-import { loadDocumentContent, saveDocumentContent } from "@/commands/document";
+import { loadDocumentContent, saveDocumentContent, upsertDocument } from "@/commands/document";
+import { assetUrlToRelativePath, relativePathToAssetUrl } from "@/lib/markdownMedia";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 interface EditorState {
   currentDocId: string | null;
@@ -16,6 +18,8 @@ interface EditorActions {
   saveContent: () => Promise<void>;
   updateContent: (markdown: string) => void;
   updateTitle: (title: string) => void;
+  /** Update relPath and currentDocId after file rename. */
+  updateRelPath: (newRelPath: string, newTitle: string) => void;
   clear: () => void;
 }
 
@@ -33,7 +37,9 @@ export const useEditorStore = create<EditorState & EditorActions>()((set, get) =
   ...initialState,
 
   loadDocument: async (id, title, relPath) => {
-    const markdown = await loadDocumentContent(relPath);
+    const workspace = useWorkspaceStore.getState().workspace;
+    const raw = await loadDocumentContent(relPath);
+    const markdown = workspace ? relativePathToAssetUrl(raw, workspace.path) : raw;
     set({
       ...initialState,
       currentDocId: id,
@@ -45,16 +51,31 @@ export const useEditorStore = create<EditorState & EditorActions>()((set, get) =
   },
 
   saveContent: async () => {
-    const { currentDocId, relPath, markdown } = get();
-    if (!currentDocId) return;
+    const { currentDocId, relPath, markdown, title } = get();
+    if (!currentDocId || !get().isDirty) return;
 
-    await saveDocumentContent(relPath, markdown);
+    const workspace = useWorkspaceStore.getState().workspace;
+    const contentToSave = workspace ? assetUrlToRelativePath(markdown, workspace.path) : markdown;
+    const { file_hash } = await saveDocumentContent(relPath, contentToSave);
     set({ isDirty: false, lastSavedAt: new Date() });
+
+    if (workspace) {
+      await upsertDocument({
+        id: currentDocId,
+        workspace_id: workspace.id,
+        title,
+        rel_path: relPath,
+        file_hash,
+      });
+    }
   },
 
   updateContent: (markdown) => set({ markdown, isDirty: true, charCount: markdown.length }),
 
   updateTitle: (title) => set({ title }),
+
+  updateRelPath: (newRelPath, newTitle) =>
+    set({ currentDocId: newRelPath, relPath: newRelPath, title: newTitle }),
 
   clear: () => set(initialState),
 }));

--- a/src/stores/fileTreeStore.ts
+++ b/src/stores/fileTreeStore.ts
@@ -1,5 +1,6 @@
 import { listen } from "@tauri-apps/api/event";
 import { create } from "zustand";
+import { deleteDocument, upsertDocument } from "@/commands/document";
 import {
   type FileTreeNode,
   fsCreateDir,
@@ -9,6 +10,8 @@ import {
   fsRename,
   scanWorkspaceTree,
 } from "@/commands/fs";
+import { useEditorStore } from "@/stores/editorStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 interface FileTreeState {
   tree: FileTreeNode[];
@@ -20,6 +23,7 @@ interface FileTreeActions {
   rescan: () => Promise<void>;
   selectFile: (id: string | null) => void;
   createFile: (parentRel: string, name: string) => Promise<string>;
+  createAndOpenFile: (parentRel: string, name: string) => Promise<string>;
   createDir: (parentRel: string, name: string) => Promise<string>;
   deleteFile: (relPath: string) => Promise<void>;
   deleteDir: (relPath: string) => Promise<void>;
@@ -50,7 +54,25 @@ export const useFileTreeStore = create<FileTreeState & FileTreeActions>()((set, 
 
   createFile: async (parentRel, name) => {
     const relPath = await fsCreateFile(parentRel, name);
+    const workspace = useWorkspaceStore.getState().workspace;
+    if (workspace) {
+      const title = relPath.split("/").pop() ?? name;
+      await upsertDocument({
+        id: relPath,
+        workspace_id: workspace.id,
+        title,
+        rel_path: relPath,
+      });
+    }
     await get().rescan();
+    return relPath;
+  },
+
+  createAndOpenFile: async (parentRel, name) => {
+    const relPath = await get().createFile(parentRel, name);
+    const title = relPath.split("/").pop() ?? name;
+    set({ selectedId: relPath });
+    await useEditorStore.getState().loadDocument(relPath, title, relPath);
     return relPath;
   },
 
@@ -62,9 +84,11 @@ export const useFileTreeStore = create<FileTreeState & FileTreeActions>()((set, 
 
   deleteFile: async (relPath) => {
     await fsDeleteFile(relPath);
+    deleteDocument(relPath).catch(() => {});
     const { selectedId } = get();
     if (selectedId === relPath) {
       set({ selectedId: null });
+      useEditorStore.getState().clear();
     }
     await get().rescan();
   },


### PR DESCRIPTION
## Summary

- 实现 Rust 端 `load_document` / `save_document`（含 blake3 hash）/ `save_media` 三个命令，替换 localStorage 桩，笔记内容真正读写磁盘 `.md` 文件
- 恢复 BlockNote image/video block，实现 `uploadFile` handler，媒体文件保存到同名资源目录
- 资源目录联动：删除/重命名 `.md` 文件时同步删除/重命名同名资源目录
- 保存时计算 blake3 hash 并同步到 `documents` 元数据表
- 配置 Tauri asset 协议，Markdown 中使用相对路径，编辑器中转换为 asset URL 显示
- 新增 Ctrl+S / Cmd+S 立即保存快捷键
- 新建笔记后自动打开编辑器（`createAndOpenFile`）
- 修复 EditorTitle 重命名后 `relPath`/`currentDocId` 不更新的 bug
- 修复嵌套 ContextMenu 事件冒泡导致右键菜单缺少重命名/删除选项
- 修复新建空文件时编辑器内容不清除、删除当前文件后编辑器不清除
- UI: 标题字号调小（`text-3xl` → `text-2xl`），状态栏字号调大（`text-[11px]` → `text-xs`）

Closes #6

## Test plan

- [ ] 新建笔记 → 编辑内容 → 等待 1.5s 自动保存 → 用外部编辑器打开 `.md` 文件确认内容正确
- [ ] 关闭应用 → 重新打开 → 点击笔记 → 确认内容完整加载
- [ ] Ctrl+S 手动保存，状态栏显示"已保存"+ 时间
- [ ] 插入图片 → 确认资源目录自动创建 → `.md` 中图片路径为相对路径
- [ ] 右键文件 → 确认出现重命名/删除选项
- [ ] 重命名笔记 → 确认资源目录同步重命名
- [ ] 删除笔记 → 确认资源目录同步删除 + 编辑器清除
- [ ] 通过标题栏重命名 → 确认文件树和磁盘文件同步更新
- [ ] 新建笔记 → 确认编辑器自动打开空白编辑区域