### PR TITLE
fix(workspace): 修复工作区打开流程及编辑器块类型

### DIFF
--- a/src-tauri/src/workspace/commands.rs
+++ b/src-tauri/src/workspace/commands.rs
@@ -255,7 +255,23 @@ pub async fn open_workspace_window(
         )));
     }
 
-    // 创建新窗口
+    // 先完成 DB 初始化和状态绑定，再创建窗口，消除竞态
+    let (conn, workspace) = ensure_workspace(&ws_path, &identity).await?;
+    let info = bind_workspace_to_window(
+        &label,
+        &path,
+        conn,
+        &workspace,
+        &identity,
+        &db_state,
+        &ws_state,
+        &config_state,
+        &watcher_state,
+        &app,
+    )
+    .await;
+
+    // 状态就绪后再创建窗口
     let new_window = WebviewWindowBuilder::new(&app, &label, WebviewUrl::App("index.html".into()))
         .title("SwarmNote")
         .inner_size(800.0, 600.0)
@@ -270,21 +286,10 @@ pub async fn open_workspace_window(
         let _ = new_window.set_title_bar_style(TitleBarStyle::Overlay);
     }
 
-    // 原子预绑定
-    let (conn, workspace) = ensure_workspace(&ws_path, &identity).await?;
-    bind_workspace_to_window(
-        &label,
-        &path,
-        conn,
-        &workspace,
-        &identity,
-        &db_state,
-        &ws_state,
-        &config_state,
-        &watcher_state,
-        &app,
-    )
-    .await;
+    // 推送工作区信息给新窗口，前端可通过事件直接获取而无需轮询
+    if let Err(e) = new_window.emit("workspace:ready", &info) {
+        log::warn!("Failed to emit workspace:ready to window '{label}': {e}");
+    }
 
     bind_window_cleanup(&new_window, &app, &label);
 

--- a/src/components/editor/NoteEditor.tsx
+++ b/src/components/editor/NoteEditor.tsx
@@ -21,11 +21,9 @@ import { useUIStore } from "@/stores/uiStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { EditorTitle } from "./EditorTitle";
 
-const { audio: _a, file: _f, ...supportedBlockSpecs } = defaultBlockSpecs;
-
 const schema = BlockNoteSchema.create({
   blockSpecs: {
-    ...supportedBlockSpecs,
+    ...defaultBlockSpecs,
     codeBlock: createCodeBlockSpec(codeBlockOptions),
   },
 });

--- a/src/components/workspace/WorkspacePicker.tsx
+++ b/src/components/workspace/WorkspacePicker.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { WorkspaceItem } from "@/components/workspace/WorkspaceItem";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 interface WorkspacePickerProps {
   mode: "fullscreen" | "dialog";
@@ -19,28 +20,41 @@ interface WorkspacePickerProps {
 
 export function WorkspacePicker({ mode, open: dialogOpen, onOpenChange }: WorkspacePickerProps) {
   const [recents, setRecents] = useState<RecentWorkspace[]>([]);
+  const openWorkspace = useWorkspaceStore((s) => s.openWorkspace);
 
   useEffect(() => {
     getRecentWorkspaces().then(setRecents);
   }, []);
 
   async function handleSelectWorkspace(path: string) {
-    await openWorkspaceWindow(path);
-    onOpenChange?.(false);
+    if (mode === "fullscreen") {
+      await openWorkspace(path);
+    } else {
+      await openWorkspaceWindow(path);
+      onOpenChange?.(false);
+    }
   }
 
   async function handleOpenFolder() {
     const selected = await open({ directory: true, title: "打开工作区文件夹" });
     if (!selected) return;
-    await openWorkspaceWindow(selected);
-    onOpenChange?.(false);
+    if (mode === "fullscreen") {
+      await openWorkspace(selected);
+    } else {
+      await openWorkspaceWindow(selected);
+      onOpenChange?.(false);
+    }
   }
 
   async function handleCreateWorkspace() {
     const selected = await open({ directory: true, title: "选择新工作区目录" });
     if (!selected) return;
-    await openWorkspaceWindow(selected);
-    onOpenChange?.(false);
+    if (mode === "fullscreen") {
+      await openWorkspace(selected);
+    } else {
+      await openWorkspaceWindow(selected);
+      onOpenChange?.(false);
+    }
   }
 
   const content = (

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -1,3 +1,4 @@
+import { listen } from "@tauri-apps/api/event";
 import { open } from "@tauri-apps/plugin-dialog";
 import { create } from "zustand";
 
@@ -49,9 +50,23 @@ export const useWorkspaceStore = create<WorkspaceState & WorkspaceActions>()((se
   initFromBackend: async () => {
     set({ isLoading: true, error: null });
     try {
+      // 先注册事件监听，再调用 get_workspace_info，避免新建窗口场景下事件丢失
+      let unlistenFn: (() => void) | null = null;
+      const unlistenPromise = listen<WorkspaceInfo>("workspace:ready", (event) => {
+        set({ workspace: event.payload });
+        maybeAutoStartP2P();
+        unlistenFn?.();
+      });
       const info = await getWorkspaceInfo();
-      set({ workspace: info });
-      if (info) maybeAutoStartP2P();
+      unlistenFn = await unlistenPromise;
+      if (info) {
+        // auto-restore 或新建窗口（Rust 已在建窗口前完成绑定）场景：直接拿到数据
+        set({ workspace: info });
+        maybeAutoStartP2P();
+        unlistenFn();
+      }
+      // info 为 null 时（全新启动无历史工作区）：保留监听，等待 workspace:ready 事件
+      // 若用户通过 WorkspacePicker fullscreen 选择，openWorkspace() 会直接 set，监听自然不触发
     } catch (e) {
       set({ error: String(e) });
     } finally {


### PR DESCRIPTION
## Summary
- WorkspacePicker fullscreen 模式改为在当前窗口加载工作区，不再新建 Tauri 窗口
- open_workspace_window：先绑定后端状态再创建窗口，消除竞态；窗口创建后 emit workspace:ready 事件
- workspaceStore.initFromBackend：在 get_workspace_info 之前注册 workspace:ready 监听，避免事件丢失
- NoteEditor：恢复 audio 和 file 块类型支持
## Test plan

- [ ] 全新启动（无历史工作区）→ 点击「打开文件夹」→ 当前窗口正常加载工作区
- [ ] 有历史工作区 → 点击最近工作区 → 当前窗口正常加载，不弹新窗口
- [ ] 已进入工作区 → toolbar 切换到另一工作区 → 新窗口正常打开并聚焦
- [ ] 编辑器中可插入 audio 和 file 块