### PR TITLE
refactor(ui): 标题栏整合工作区切换与快捷操作，优化设置页布局

### DIFF
--- a/src-tauri/src/workspace/commands.rs
+++ b/src-tauri/src/workspace/commands.rs
@@ -317,12 +317,20 @@ pub async fn open_settings_window(app: tauri::AppHandle, route: Option<String>) 
         return Ok(());
     }
 
-    WebviewWindowBuilder::new(&app, "settings", WebviewUrl::App(target_route.into()))
-        .title("SwarmNote 设置")
-        .inner_size(720.0, 520.0)
-        .resizable(false)
-        .build()
-        .map_err(|e| AppError::Window(format!("Failed to create settings window: {e}")))?;
+    let settings_window =
+        WebviewWindowBuilder::new(&app, "settings", WebviewUrl::App(target_route.into()))
+            .title("SwarmNote 设置")
+            .inner_size(720.0, 520.0)
+            .resizable(false)
+            .decorations(cfg!(target_os = "macos"))
+            .build()
+            .map_err(|e| AppError::Window(format!("Failed to create settings window: {e}")))?;
+
+    #[cfg(target_os = "macos")]
+    {
+        use tauri::TitleBarStyle;
+        let _ = settings_window.set_title_bar_style(TitleBarStyle::Overlay);
+    }
 
     Ok(())
 }

--- a/src-tauri/src/workspace/commands.rs
+++ b/src-tauri/src/workspace/commands.rs
@@ -317,7 +317,7 @@ pub async fn open_settings_window(app: tauri::AppHandle, route: Option<String>) 
         return Ok(());
     }
 
-    let settings_window =
+    let _settings_window =
         WebviewWindowBuilder::new(&app, "settings", WebviewUrl::App(target_route.into()))
             .title("SwarmNote 设置")
             .inner_size(720.0, 520.0)
@@ -329,7 +329,7 @@ pub async fn open_settings_window(app: tauri::AppHandle, route: Option<String>) 
     #[cfg(target_os = "macos")]
     {
         use tauri::TitleBarStyle;
-        let _ = settings_window.set_title_bar_style(TitleBarStyle::Overlay);
+        let _ = _settings_window.set_title_bar_style(TitleBarStyle::Overlay);
     }
 
     Ok(())

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,63 +1,28 @@
 import { Trans, useLingui } from "@lingui/react/macro";
-import {
-  ChevronsUpDown,
-  FilePlus,
-  FolderOpen,
-  FolderPlus,
-  Globe,
-  Monitor,
-  Moon,
-  PanelLeft,
-  Settings,
-  Sun,
-} from "lucide-react";
+import { FilePlus, FolderOpen, FolderPlus, PanelLeft } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { getDeviceInfo } from "@/commands/identity";
 import { openSettingsWindow } from "@/commands/workspace";
 import { FileTree } from "@/components/filetree/FileTree";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { WorkspacePopover } from "@/components/workspace/WorkspacePopover";
-import { type Locale, locales } from "@/i18n";
 import { isMac, modKey } from "@/lib/utils";
 import { useFileTreeStore } from "@/stores/fileTreeStore";
 import { useNetworkStore } from "@/stores/networkStore";
-import { usePairingStore } from "@/stores/pairingStore";
 import { useUIStore } from "@/stores/uiStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
-
-const themeIcons = { light: Sun, dark: Moon, system: Monitor } as const;
-const themeOrder: Array<"light" | "dark" | "system"> = ["light", "dark", "system"];
-const localeKeys = Object.keys(locales) as Locale[];
 
 export function Sidebar() {
   const { t } = useLingui();
   const sidebarOpen = useUIStore((s) => s.sidebarOpen);
   const toggleSidebar = useUIStore((s) => s.toggleSidebar);
-  const theme = useUIStore((s) => s.theme);
-  const setTheme = useUIStore((s) => s.setTheme);
-  const locale = useUIStore((s) => s.locale);
-  const setLocale = useUIStore((s) => s.setLocale);
   const workspace = useWorkspaceStore((s) => s.workspace);
   const rescan = useFileTreeStore((s) => s.rescan);
   const createAndOpenFile = useFileTreeStore((s) => s.createAndOpenFile);
   const createDir = useFileTreeStore((s) => s.createDir);
 
-  const pairedDevices = usePairingStore((s) => s.pairedDevices);
-  const onlineCount = pairedDevices.filter((d) => d.isOnline).length;
-  const [deviceName, setDeviceName] = useState("...");
-
   const nodeStatus = useNetworkStore((s) => s.status);
   const connectedPeers = useNetworkStore((s) => s.connectedPeers);
-
-  const ThemeIcon = themeIcons[theme];
-
-  useEffect(() => {
-    getDeviceInfo()
-      .then((info) => setDeviceName(info.device_name))
-      .catch(() => setDeviceName("SwarmNote"));
-  }, []);
 
   // Rescan when workspace changes
   useEffect(() => {
@@ -65,16 +30,6 @@ export function Sidebar() {
       rescan();
     }
   }, [workspace, rescan]);
-
-  function cycleTheme() {
-    const idx = themeOrder.indexOf(theme);
-    setTheme(themeOrder[(idx + 1) % themeOrder.length]);
-  }
-
-  function toggleLocale() {
-    const idx = localeKeys.indexOf(locale);
-    setLocale(localeKeys[(idx + 1) % localeKeys.length]);
-  }
 
   const handleCreateFile = useCallback(() => {
     createAndOpenFile("", t`新建笔记`);
@@ -172,23 +127,8 @@ export function Sidebar() {
           <FileTree width={232} height={treeHeight} />
         </div>
 
-        {/* Workspace + Device Info + Quick Settings */}
-        <div className="flex flex-col gap-2 border-t border-sidebar-border px-1 pt-2">
-          {/* Workspace row */}
-          <WorkspacePopover>
-            <button
-              type="button"
-              className="flex w-full items-center gap-1.5 rounded-sm px-1 py-1 text-left hover:bg-sidebar-accent"
-            >
-              <FolderOpen className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              <span className="min-w-0 flex-1 truncate text-xs font-medium text-sidebar-foreground">
-                {workspace?.name ?? <Trans>选择工作区</Trans>}
-              </span>
-              <ChevronsUpDown className="h-3 w-3 shrink-0 text-muted-foreground" />
-            </button>
-          </WorkspacePopover>
-
-          {/* Network status indicator */}
+        {/* Network status indicator */}
+        <div className="border-t border-sidebar-border px-1 pt-2">
           <button
             type="button"
             className="flex w-full items-center gap-1.5 rounded-sm px-1 py-1 text-left hover:bg-sidebar-accent"
@@ -199,7 +139,7 @@ export function Sidebar() {
                 nodeStatus === "running"
                   ? "bg-green-500"
                   : nodeStatus === "starting"
-                    ? "bg-yellow-500 animate-pulse"
+                    ? "animate-pulse bg-yellow-500"
                     : nodeStatus === "error"
                       ? "bg-red-500"
                       : "bg-gray-400"
@@ -217,78 +157,6 @@ export function Sidebar() {
                     : "未连接"}
             </span>
           </button>
-
-          {/* Device info + quick settings */}
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              className="flex min-w-0 flex-1 items-center gap-2 rounded-sm px-1 py-1 text-left hover:bg-sidebar-accent"
-              onClick={() => openSettingsWindow("devices")}
-            >
-              <Monitor className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              <div className="flex min-w-0 flex-1 flex-col gap-px">
-                <span className="text-xs font-medium text-sidebar-foreground">{deviceName}</span>
-                <span className="truncate text-[10px] text-muted-foreground">
-                  {onlineCount > 0 ? (
-                    <>
-                      <span className="inline-block h-1.5 w-1.5 rounded-full bg-green-500" />{" "}
-                      {onlineCount} 在线
-                    </>
-                  ) : (
-                    "无设备在线"
-                  )}
-                </span>
-              </div>
-            </button>
-            <div className="flex shrink-0 gap-0.5">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    className="text-muted-foreground"
-                    onClick={cycleTheme}
-                    aria-label={t`切换主题`}
-                  >
-                    <ThemeIcon className="h-3.5 w-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <Trans>切换主题</Trans>
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    className="text-muted-foreground"
-                    onClick={toggleLocale}
-                    aria-label={t`切换语言`}
-                  >
-                    <Globe className="h-3.5 w-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>{locales[locale]}</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    className="text-muted-foreground"
-                    onClick={() => openSettingsWindow("general")}
-                    aria-label={t`设置`}
-                  >
-                    <Settings className="h-3.5 w-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <Trans>设置</Trans>
-                </TooltipContent>
-              </Tooltip>
-            </div>
-          </div>
         </div>
       </div>
     </aside>

--- a/src/components/layout/TitleBar.tsx
+++ b/src/components/layout/TitleBar.tsx
@@ -1,8 +1,19 @@
 import { useLingui } from "@lingui/react/macro";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { Minus, PanelLeft, PenLine, Search, Square, X } from "lucide-react";
+import {
+  ChevronsUpDown,
+  Minus,
+  PanelLeft,
+  PenLine,
+  Search,
+  Settings,
+  Square,
+  X,
+} from "lucide-react";
+import { openSettingsWindow } from "@/commands/workspace";
 import { OPEN_COMMAND_PALETTE } from "@/components/layout/CommandPalette";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { WorkspacePopover } from "@/components/workspace/WorkspacePopover";
 import { isMac, modKey } from "@/lib/utils";
 import { useUIStore } from "@/stores/uiStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
@@ -24,7 +35,7 @@ export function TitleBar() {
     >
       {/* Left: Logo + Nav */}
       <div
-        className={`flex items-center gap-3 ${needsTrafficLightPadding ? "pl-[70px]" : ""}`}
+        className={`flex items-center gap-3 ${needsTrafficLightPadding ? "pl-17.5" : ""}`}
         data-tauri-drag-region
       >
         <div className="group/logo flex items-center gap-1.5">
@@ -52,9 +63,15 @@ export function TitleBar() {
           <span className="text-sm font-semibold text-foreground">SwarmNote</span>
         </div>
         <div className="h-4 w-px bg-border" />
-        <span className="text-[13px] font-medium text-foreground">
-          {workspace?.name ?? "SwarmNote"}
-        </span>
+        <WorkspacePopover side="bottom">
+          <button
+            type="button"
+            className="flex items-center gap-1 rounded-md px-1.5 py-1 text-[13px] font-medium text-foreground hover:bg-muted"
+          >
+            <span className="max-w-32 truncate">{workspace?.name ?? "SwarmNote"}</span>
+            <ChevronsUpDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+          </button>
+        </WorkspacePopover>
       </div>
 
       {/* Right: Search + Settings + Window Controls */}
@@ -62,12 +79,25 @@ export function TitleBar() {
         <button
           type="button"
           onClick={() => document.dispatchEvent(new CustomEvent(OPEN_COMMAND_PALETTE))}
-          className="flex items-center gap-1.5 rounded-md bg-secondary px-2.5 py-[5px] text-muted-foreground hover:bg-secondary/80"
+          className="flex items-center gap-1.5 rounded-md bg-secondary px-2.5 py-1.25 text-muted-foreground hover:bg-secondary/80"
         >
           <Search className="h-3.5 w-3.5" />
           <span className="text-xs">{t`搜索...`}</span>
           <span className="text-[10px] font-medium">{modKey}P</span>
         </button>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => openSettingsWindow("general")}
+              className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted"
+            >
+              <Settings className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>{t`设置`}</TooltipContent>
+        </Tooltip>
 
         {!isMac && (
           <>

--- a/src/components/workspace/WorkspacePopover.tsx
+++ b/src/components/workspace/WorkspacePopover.tsx
@@ -13,9 +13,10 @@ import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 interface WorkspacePopoverProps {
   children: React.ReactNode;
+  side?: "top" | "bottom" | "left" | "right";
 }
 
-export function WorkspacePopover({ children }: WorkspacePopoverProps) {
+export function WorkspacePopover({ children, side = "bottom" }: WorkspacePopoverProps) {
   const [open, setOpen] = useState(false);
   const [recents, setRecents] = useState<RecentWorkspace[]>([]);
   const workspace = useWorkspaceStore((s) => s.workspace);
@@ -40,7 +41,7 @@ export function WorkspacePopover({ children }: WorkspacePopoverProps) {
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
-      <PopoverContent className="w-64 p-1" side="top" align="start">
+      <PopoverContent className="w-64 p-1" side={side} align="start">
         <div className="flex flex-col">
           {recents.map((ws) => {
             const isCurrent = workspace?.path === ws.path;

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -1,9 +1,10 @@
 import { createFileRoute, Outlet, useLocation, useRouter } from "@tanstack/react-router";
 import { listen } from "@tauri-apps/api/event";
-import { Info, MonitorSmartphone, Network, Settings } from "lucide-react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { Info, Minus, MonitorSmartphone, Network, Settings, X } from "lucide-react";
 import { useEffect } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { cn } from "@/lib/utils";
+import { cn, isMac } from "@/lib/utils";
 
 const navItems = [
   { to: "/settings/general", icon: Settings, label: "通用" },
@@ -15,6 +16,7 @@ const navItems = [
 function SettingsLayout() {
   const router = useRouter();
   const { pathname } = useLocation();
+  const appWindow = getCurrentWindow();
 
   useEffect(() => {
     const unlisten = listen<string>("navigate", (event) => {
@@ -26,49 +28,88 @@ function SettingsLayout() {
   }, [router]);
 
   return (
-    <div className="flex h-screen bg-muted/30">
-      {/* Sidebar */}
-      <nav className="flex w-55 flex-col border-r bg-background/60">
-        <div className="p-5 pb-2">
-          <h2 className="text-base font-semibold tracking-tight">设置</h2>
-          <p className="mt-0.5 text-xs text-muted-foreground">管理应用偏好与设备</p>
-        </div>
-
-        <div className="flex flex-col gap-0.5 px-3 pt-2">
-          {navItems.map((item) => {
-            const isActive = pathname.startsWith(item.to);
-            return (
+    <div className="flex h-screen flex-col bg-muted/30">
+      {/* Title Bar */}
+      <header
+        data-tauri-drag-region
+        className="flex h-10 shrink-0 items-center justify-between border-b border-border bg-background/60 px-4"
+      >
+        {isMac ? (
+          <div className="w-17.5" data-tauri-drag-region />
+        ) : (
+          <span className="text-sm font-semibold text-foreground" data-tauri-drag-region>
+            设置
+          </span>
+        )}
+        <div className="flex items-center gap-1">
+          {!isMac && (
+            <>
               <button
-                key={item.to}
                 type="button"
-                onClick={() => router.navigate({ to: item.to })}
-                className={cn(
-                  "flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition-all",
-                  isActive
-                    ? "bg-background font-medium text-foreground shadow-sm"
-                    : "text-muted-foreground hover:bg-background/60 hover:text-foreground",
-                )}
+                onClick={() => appWindow.minimize()}
+                className="flex h-7 w-9 items-center justify-center text-muted-foreground hover:bg-muted"
               >
-                <item.icon className="h-4 w-4 shrink-0" />
-                {item.label}
+                <Minus className="h-3.5 w-3.5" />
               </button>
-            );
-          })}
+              <button
+                type="button"
+                onClick={() => appWindow.close()}
+                className="flex h-7 w-9 items-center justify-center text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </>
+          )}
         </div>
+      </header>
 
-        {/* Bottom branding */}
-        <div className="mt-auto border-t px-5 py-4">
-          <div className="text-xs text-muted-foreground">SwarmNote</div>
-          <div className="text-[11px] text-muted-foreground/60">v0.2.0</div>
-        </div>
-      </nav>
+      {/* Main Content */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Sidebar */}
+        <nav className="flex w-55 flex-col border-r bg-background/60">
+          <div className="p-5 pb-2">
+            {isMac && <h2 className="text-base font-semibold tracking-tight">设置</h2>}
+            <p className={cn("text-xs text-muted-foreground", isMac && "mt-0.5")}>
+              管理应用偏好与设备
+            </p>
+          </div>
 
-      {/* Content */}
-      <ScrollArea className="flex-1">
-        <main className="mx-auto max-w-2xl px-8 py-8">
-          <Outlet />
-        </main>
-      </ScrollArea>
+          <div className="flex flex-col gap-0.5 px-3 pt-2">
+            {navItems.map((item) => {
+              const isActive = pathname.startsWith(item.to);
+              return (
+                <button
+                  key={item.to}
+                  type="button"
+                  onClick={() => router.navigate({ to: item.to })}
+                  className={cn(
+                    "flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition-all",
+                    isActive
+                      ? "bg-background font-medium text-foreground shadow-sm"
+                      : "text-muted-foreground hover:bg-background/60 hover:text-foreground",
+                  )}
+                >
+                  <item.icon className="h-4 w-4 shrink-0" />
+                  {item.label}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Bottom branding */}
+          <div className="mt-auto border-t px-5 py-4">
+            <div className="text-xs text-muted-foreground">SwarmNote</div>
+            <div className="text-[11px] text-muted-foreground/60">v0.2.0</div>
+          </div>
+        </nav>
+
+        {/* Content */}
+        <ScrollArea className="flex-1">
+          <main className="mx-auto max-w-2xl px-8 py-8">
+            <Outlet />
+          </main>
+        </ScrollArea>
+      </div>
     </div>
   );
 }

--- a/src/routes/settings/devices.tsx
+++ b/src/routes/settings/devices.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { Loader2, RefreshCw } from "lucide-react";
-import { useEffect } from "react";
+import { Loader2, Monitor, RefreshCw } from "lucide-react";
+import { useEffect, useState } from "react";
+import { type DeviceInfo, getDeviceInfo } from "@/commands/identity";
 import { CodePairingCard } from "@/components/pairing/CodePairingCard";
 import { NearbyDeviceCard } from "@/components/pairing/NearbyDeviceCard";
 import { PairedDeviceCard } from "@/components/pairing/PairedDeviceCard";
@@ -13,11 +14,18 @@ function DevicesPage() {
   const nearbyDevices = usePairingStore((s) => s.nearbyDevices);
   const isLoading = usePairingStore((s) => s.isLoading);
   const refresh = usePairingStore((s) => s.refresh);
+  const [myDevice, setMyDevice] = useState<DeviceInfo | null>(null);
 
   useEffect(() => {
     setupPairingListeners();
     refresh();
   }, [refresh]);
+
+  useEffect(() => {
+    getDeviceInfo()
+      .then(setMyDevice)
+      .catch(() => null);
+  }, []);
 
   return (
     <div>
@@ -36,6 +44,27 @@ function DevicesPage() {
       </div>
 
       <div className="space-y-4">
+        {/* My Device Card */}
+        <div className="rounded-xl border bg-card">
+          <div className="flex items-center gap-4 px-5 py-4">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary/10">
+              <Monitor className="h-5.5 w-5.5 text-primary" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="truncate font-medium text-foreground">
+                {myDevice?.device_name ?? "—"}
+              </div>
+              <div className="mt-0.5 text-xs text-muted-foreground">
+                {myDevice ? `${myDevice.os} · ${myDevice.platform}` : "—"}
+              </div>
+            </div>
+            {myDevice && (
+              <code className="shrink-0 rounded-md bg-muted px-2.5 py-1 text-xs text-muted-foreground">
+                {myDevice.peer_id.slice(0, 20)}…
+              </code>
+            )}
+          </div>
+        </div>
         {/* Paired Devices */}
         <div className="rounded-xl border bg-card">
           <div className="flex items-center justify-between px-5 py-3">

--- a/src/routes/settings/network.tsx
+++ b/src/routes/settings/network.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { Fingerprint, Play, Power, Shield, Users, Zap } from "lucide-react";
+import { Fingerprint, Power, Shield, Users, Zap } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { getDeviceInfo } from "@/commands/identity";
@@ -7,17 +7,53 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
 import { type NodeStatus, useNetworkStore } from "@/stores/networkStore";
 import { usePreferencesStore } from "@/stores/preferencesStore";
 
 const statusConfig: Record<
   NodeStatus,
-  { label: string; variant: "default" | "secondary" | "destructive" | "outline" }
+  {
+    label: string;
+    description: string;
+    variant: "default" | "secondary" | "destructive" | "outline";
+    indicatorClass: string;
+    iconClass: string;
+    cardClass: string;
+  }
 > = {
-  stopped: { label: "已停止", variant: "secondary" },
-  starting: { label: "启动中...", variant: "outline" },
-  running: { label: "运行中", variant: "default" },
-  error: { label: "错误", variant: "destructive" },
+  stopped: {
+    label: "已停止",
+    description: "P2P 节点未运行",
+    variant: "secondary",
+    indicatorClass: "bg-muted",
+    iconClass: "text-muted-foreground",
+    cardClass: "border-border",
+  },
+  starting: {
+    label: "启动中...",
+    description: "正在建立 P2P 连接",
+    variant: "outline",
+    indicatorClass: "bg-yellow-500 animate-pulse",
+    iconClass: "text-white",
+    cardClass: "border-yellow-500/30 bg-yellow-500/5",
+  },
+  running: {
+    label: "运行中",
+    description: "",
+    variant: "default",
+    indicatorClass: "bg-green-500",
+    iconClass: "text-white",
+    cardClass: "border-green-500/30 bg-green-500/5",
+  },
+  error: {
+    label: "错误",
+    description: "节点启动失败",
+    variant: "destructive",
+    indicatorClass: "bg-red-500",
+    iconClass: "text-white",
+    cardClass: "border-red-500/30 bg-red-500/5",
+  },
 };
 
 function SettingCard({
@@ -93,7 +129,8 @@ function NetworkSettingsPage() {
     getDeviceInfo().then((info) => setPeerId(info.peer_id));
   }, []);
 
-  const { label, variant } = statusConfig[status];
+  const { label, variant, description, indicatorClass, iconClass, cardClass } =
+    statusConfig[status];
 
   const handleStop = () => {
     setShowStopConfirm(true);
@@ -104,6 +141,15 @@ function NetworkSettingsPage() {
     await stopNode(true);
   };
 
+  const statusDescription =
+    status === "running"
+      ? connectedPeers.length > 0
+        ? `已连接 ${connectedPeers.length} 台设备`
+        : "已连接，暂无设备在线"
+      : status === "error"
+        ? error || description
+        : description;
+
   return (
     <div>
       <div className="mb-6">
@@ -112,20 +158,46 @@ function NetworkSettingsPage() {
       </div>
 
       <div className="space-y-4">
-        {/* Node Status Card */}
-        <SettingCard
-          title="节点状态"
-          description="当前 P2P 节点运行状态"
-          action={<Badge variant={variant}>{label}</Badge>}
-        >
-          <div className="space-y-1">
-            {/* Error message */}
-            {status === "error" && error && (
-              <div className="my-1 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
-                {error}
+        {/* Network Power Control — prominent status + toggle */}
+        <div className={cn("rounded-xl border-2 px-5 py-4", cardClass)}>
+          <div className="flex items-center gap-4">
+            <div
+              className={cn(
+                "flex h-11 w-11 shrink-0 items-center justify-center rounded-xl",
+                indicatorClass,
+              )}
+            >
+              <Power className={cn("h-5 w-5", iconClass)} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="font-medium">{label}</span>
+                <Badge variant={variant} className="text-[10px]">
+                  P2P
+                </Badge>
               </div>
+              <p className="mt-0.5 text-xs text-muted-foreground">{statusDescription}</p>
+            </div>
+            {status === "running" ? (
+              <Button variant="outline" size="sm" onClick={handleStop} className="shrink-0">
+                停止节点
+              </Button>
+            ) : (
+              <Button
+                size="sm"
+                onClick={startNode}
+                disabled={status === "starting"}
+                className="shrink-0"
+              >
+                {status === "starting" ? "启动中..." : "启动节点"}
+              </Button>
             )}
+          </div>
+        </div>
 
+        {/* Node Status Card */}
+        <SettingCard title="节点信息" description="当前 P2P 节点详情">
+          <div className="space-y-1">
             {/* Peer ID */}
             {peerId && (
               <SettingRow icon={Fingerprint} label="Peer ID" description="本设备的 P2P 网络标识">
@@ -156,34 +228,20 @@ function NetworkSettingsPage() {
                 </SettingRow>
               </>
             )}
+
+            {!peerId && status === "stopped" && (
+              <p className="py-2 text-center text-xs text-muted-foreground">
+                启动节点后显示详细信息
+              </p>
+            )}
           </div>
         </SettingCard>
 
-        {/* Control Card */}
-        <SettingCard title="节点控制" description="启动或停止 P2P 节点">
-          <div className="space-y-1">
-            <SettingRow
-              icon={status === "running" ? Power : Play}
-              label={status === "running" ? "停止节点" : "启动节点"}
-              description={
-                status === "running" ? "停止后将断开所有 P2P 连接" : "启动 P2P 节点以同步笔记"
-              }
-            >
-              {status === "running" ? (
-                <Button variant="destructive" size="sm" onClick={handleStop}>
-                  停止
-                </Button>
-              ) : (
-                <Button size="sm" onClick={startNode} disabled={status === "starting"}>
-                  {status === "starting" ? "启动中..." : "启动"}
-                </Button>
-              )}
-            </SettingRow>
-            <Separator />
-            <SettingRow icon={Zap} label="自动启动" description="打开工作区时自动启动 P2P 节点">
-              <Switch checked={autoStartP2P} onCheckedChange={setAutoStartP2P} />
-            </SettingRow>
-          </div>
+        {/* Auto-start Setting */}
+        <SettingCard title="启动设置">
+          <SettingRow icon={Zap} label="自动启动" description="打开工作区时自动启动 P2P 节点">
+            <Switch checked={autoStartP2P} onCheckedChange={setAutoStartP2P} />
+          </SettingRow>
         </SettingCard>
       </div>
 


### PR DESCRIPTION
## Summary

- 将工作区切换 Popover 和设置按钮从侧边栏迁移至标题栏，侧边栏底部区域精简为仅展示网络状态
- 设置窗口新增跨平台原生标题栏：macOS 使用 TitleBarStyle::Overlay，Windows/Linux 显示自定义最小化 + 关闭按钮
- 网络设置页重构：新增突出的节点状态/启停卡片，拆分"节点信息"与"启动设置"两张卡片
- 设备设置页顶部新增本机设备信息卡（设备名、OS/平台、Peer ID 前 20 位）
- WorkspacePopover 新增 `side` prop，支持从标题栏向下弹出

## Test plan

- [ ] macOS：标题栏红绿灯正常，工作区弹窗从标题栏向下展开，设置窗口 Overlay 标题栏正常
- [ ] Windows/Linux：标题栏自定义最小化/关闭按钮正常，设置窗口无系统装饰但有自定义按钮
- [ ] 侧边栏底部仅显示网络状态，无设备信息/主题/语言按钮
- [ ] 设备设置页能正确显示本机设备名和 Peer ID
- [ ] 网络设置页节点启停按钮功能正常，状态卡颜色随状态变化
