### PR TITLE
feat(workspace): workspace list exchange API and UUID-first state (#46)

### DIFF
--- a/milestones/v0.2.1/design/workspace-sync-edge-cases.md
+++ b/milestones/v0.2.1/design/workspace-sync-edge-cases.md
@@ -1,0 +1,299 @@
+# 工作区同步边界情况分析
+
+> 讨论日期：2026-04-02
+> 关联 Issue：#46 后端工作区列表交换 API、#28 CRDT 同步
+
+## 协议选型
+
+**工作区列表交换使用 Req-Resp 协议**，不使用 GossipSub。
+
+| 维度 | Req-Resp | GossipSub |
+|------|----------|-----------|
+| 语义 | 查询-应答，适合"给我你的列表" | 发布-订阅，适合持续流 |
+| 寻址 | 点对点（指定 peer_id） | 广播（所有订阅者） |
+| 响应 | 同步等待，可超时 | 异步投递，无确认 |
+| 适用 | 一次性查询 ✓ | 实时增量更新 |
+
+## 前置重构：WorkspaceState/DbState 主键改为 UUID
+
+### 现状
+
+当前所有运行时状态以 window label 为主键：
+
+```
+WorkspaceState:  HashMap<window_label, WorkspaceInfo>
+DbState:         HashMap<window_label, DatabaseConnection>
+YDocManager:     HashMap<(window_label, doc_id), YDoc>
+```
+
+window label 是 Tauri 窗口的临时标识（如 `"main"`, `"ws-abc123"`），不是工作区的身份。UUID 存在 `WorkspaceInfo.id` 中但从不作为索引。
+
+### 问题
+
+同步协议按 UUID 寻址（对方不知道你的 window label），但运行时状态按 label 索引。每次同步操作都需要遍历找 UUID，架构不匹配。
+
+### 重构方案
+
+改为 UUID 做主键，label 作为辅助索引：
+
+```rust
+struct WorkspaceState {
+    workspaces: RwLock<HashMap<Uuid, WorkspaceInfo>>,  // 主索引
+    bindings: RwLock<HashMap<String, Uuid>>,           // label → uuid
+}
+
+struct DbState {
+    devices_db: DatabaseConnection,
+    workspace_dbs: RwLock<HashMap<Uuid, DatabaseConnection>>,  // 主索引
+}
+```
+
+对外提供两种访问路径：
+- Tauri 命令层：`get_by_label(label)` → 内部 resolve label → uuid → 数据
+- 同步层：`get_by_uuid(uuid)` → 直接索引
+
+命令签名不变（仍接收 Tauri window label），转换逻辑封装在 state 层。
+
+### 改动范围
+
+| 文件 | 改动 |
+|------|------|
+| `workspace/state.rs` | 重写主索引 + 加 bind/unbind/resolve 方法 |
+| `workspace/commands.rs` | 小改，用 `_by_label` 便捷方法 |
+| `document/commands.rs` | 小改，`workspace_db_by_label` |
+| `fs/watcher.rs` | key 改 uuid |
+| `yjs/manager.rs` | key 改 uuid |
+| 前端 | 不影响（label 是 Tauri 内部概念） |
+
+此重构作为 #46 的前置步骤一起实施。
+
+---
+
+## 关键设计决策
+
+### 只返回当前已打开的工作区
+
+设备收到 `WorkspaceRequest::ListWorkspaces` 时，只返回 `DbState.workspace_dbs` 中已打开的工作区，不返回 `recent_workspaces` 中已关闭的。
+
+**理由**：
+- 已打开 = DB 已连接，doc_count 可查，后续 DocList/StateVector 可立即响应
+- 未打开 = 无 DB 连接，需要临时打开，引入隐式生命周期管理
+- `recent_workspaces` 中的路径可能已失效（目录删除/移动），返回后对方无法同步
+- 如果工作区没在任何在线设备上打开，即使知道它存在也无法同步
+
+### 协议结构（方案 A：独立 Workspace 变体）
+
+```rust
+enum AppRequest {
+    Pairing(PairingRequest),
+    Workspace(WorkspaceRequest),  // 新增
+    Sync(SyncRequest),
+}
+
+enum AppResponse {
+    Pairing(PairingResponse),
+    Workspace(WorkspaceResponse),  // 新增
+    Sync(SyncResponse),
+}
+
+enum WorkspaceRequest {
+    ListWorkspaces,
+}
+
+enum WorkspaceResponse {
+    WorkspaceList { workspaces: Vec<WorkspaceMeta> },
+}
+
+struct WorkspaceMeta {
+    uuid: Uuid,
+    name: String,
+    doc_count: u32,
+    updated_at: DateTime<Utc>,
+}
+```
+
+三个顶层变体对应三个生命周期阶段：
+- **Pairing** → 信任建立（谁能跟我通信）
+- **Workspace** → 资源发现（对方有什么工作区）
+- **Sync** → 数据同步（CRDT 状态交换）
+
+Workspace 独立出来为 v0.3.0 的工作区共享/权限扩展预留空间。
+
+## 边界情况
+
+### 1. 多设备同一工作区的合并展示
+
+**场景**：
+```
+A 在线:  uuid-1("笔记", 50篇, updated_at: 10:30)
+B 在线:  uuid-1("笔记", 47篇, updated_at: 09:15)
+C 查询合并列表
+```
+
+**方案**：前端按 UUID 去重合并，显示一条带可用来源数：
+```
+uuid-1  "笔记"  50篇  · 来自 2 台设备
+```
+
+- `name`：取 `updated_at` 最新的那个设备的 name
+- `doc_count`：取最大值（更完整的副本）
+- 同步时选 RTT 最低的 peer（最快完成全量传输）
+
+### 2. 同步过程中设备离线
+
+**场景**：
+```
+C 正在从 B 全量同步 uuid-2（100篇文档）
+已完成 40 篇 → B 突然离线
+```
+
+**方案**：全量同步采用 per-doc 的 req-resp 循环，不是一次性大包：
+```
+DocList → 得到 100 个 doc_id → 逐个 FullSync/StateVector
+                                ↓
+第 41 个超时 → 标记为"部分同步"
+                                ↓
+B 重新上线 → 从未完成的 doc_id 继续
+```
+
+**同步状态机**：
+```
+IDLE → FETCHING_DOC_LIST → SYNCING_DOCS → COMPLETED
+                                ↑    ↓
+                           peer 离线/超时
+                                ↓
+                         PARTIAL_SYNCED
+                                ↓
+                         peer 重连 → 从断点继续
+```
+
+per-doc 粒度的好处：
+- 断点续传天然支持
+- 已同步的文档立即可用
+- 和现有 `SyncRequest::StateVector/FullSync` 设计一致
+
+### 3. 工作区改名
+
+**场景**：
+```
+A: uuid-1, 目录名 "Notes"
+B: uuid-1, 目录名 "MyNotes"（用户在文件系统重命名了目录）
+```
+
+**方案**：v0.2.1 不同步 workspace name。
+
+- `WorkspaceIdentity.name` 由本地目录名派生，每台设备独立
+- 合并展示时取 `updated_at` 最新的设备的 name
+- 用户创建本地工作区时可自定义目录名
+- workspace name 同步推迟到后续版本（需 last-write-wins 或 CRDT）
+
+### 4. 本地已存在同 UUID 工作区
+
+**场景**：
+```
+C 之前已从 A 同步过 uuid-1
+现在查询列表，B 也报告了 uuid-1
+```
+
+**方案**：后端命令返回时标记 `is_local: true`：
+```
+uuid-1  "笔记"  50篇  · 已在本地 ✓  (灰色不可选)
+uuid-2  "工作"  30篇  · 来自 B       (可选择同步)
+```
+
+**is_local 判断**：
+- 优先匹配 `WorkspaceState.infos` 中已打开的工作区 UUID
+- 补充扫描 `GlobalConfig.recent_workspaces` 中的 `.swarmnote/workspace.json` UUID
+- 或维护全局 `known_workspace_uuids: HashSet<Uuid>` 缓存（启动时初始化）
+
+**注意**：本地已存在但未打开的工作区，UUID 匹配需要读取文件系统上的 `workspace.json`，有 I/O 开销。可在 `get_remote_workspaces` 命令中一次性扫描。
+
+### 5. 并发配对同步
+
+**场景**：
+```
+A 和 B 同时配对成功
+A 向 B 发 ListWorkspaces
+B 同时向 A 发 ListWorkspaces
+```
+
+**结论**：完全安全。Req-resp 是对称的，两边独立处理。
+
+更极端的场景：
+```
+A 有 uuid-1 (v1)，B 有 uuid-1 (v2)
+A 选择同步 uuid-1 from B，B 同时选择同步 uuid-1 from A
+→ 两边同时做 StateVector 交换 → CRDT 合并 → 两边都得到 v1∪v2 → 一致 ✓
+```
+
+CRDT 保证了并发同步的安全性，无需额外协调。
+
+### 6. 空工作区
+
+**场景**：
+```
+B 新建了 uuid-3 但还没写任何笔记
+B 报告: {uuid-3, "新工作区", doc_count: 0}
+```
+
+**方案**：前端展示但不主动推荐。doc_count=0 的工作区灰色显示或添加提示"空工作区"。技术上允许同步（创建空的本地工作区结构）。
+
+### 7. 请求超时
+
+**场景**：
+```
+C 向 A、B、D 三台设备发送 ListWorkspaces
+A 2s 内响应，B 5s 内响应，D 始终无响应（网络差）
+```
+
+**方案**：
+- 单个 peer 超时 5s（不阻塞其他 peer）
+- 并发向所有已配对在线 peer 发送请求
+- 收集到的响应立即返回，超时的 peer 跳过
+- 前端可提示"D 设备无响应，部分工作区可能未列出"
+
+### 8. 协议版本不兼容
+
+**场景**：
+```
+A 是 v0.2.1（支持 WorkspaceRequest）
+B 是 v0.2.0（不识别 WorkspaceRequest）
+```
+
+**方案**：
+- B 收到未知的 AppRequest 变体 → CBOR 反序列化失败 → Req-resp 超时
+- A 端捕获超时错误，跳过 B
+- 前端提示"B 设备版本过旧，请更新后重试"
+- 可选：通过 Identify 协议的 agent_version 字段提前判断对方版本
+
+## WorkspaceMeta 字段设计
+
+```rust
+struct WorkspaceMeta {
+    uuid: Uuid,          // 跨设备唯一标识
+    name: String,        // 目录名派生，用于展示
+    doc_count: u32,      // 文档数量（不含已删除）
+    updated_at: i64,     // 最后更新时间戳（ms），用于去重排序
+}
+```
+
+**不包含的字段**：
+- `path` — 文件系统路径是设备特有的，不应跨设备传输
+- `created_by` — 创建者 PeerId 对同步决策无影响
+- `created_at` — 创建时间对同步决策无影响
+
+## RemoteWorkspaceInfo（Tauri 命令返回类型）
+
+```rust
+struct RemoteWorkspaceInfo {
+    uuid: Uuid,
+    name: String,
+    doc_count: u32,
+    updated_at: i64,
+    peer_id: String,     // 来源设备
+    peer_name: String,   // 来源设备名
+    is_local: bool,      // 本地是否已存在
+}
+```
+
+前端合并逻辑：按 `uuid` 分组 → 每组取 `updated_at` 最新的 `name` 和最大 `doc_count` → 标记 `sources: Vec<peer_name>`。

--- a/src-tauri/src/device/mod.rs
+++ b/src-tauri/src/device/mod.rs
@@ -20,7 +20,7 @@ pub enum ConnectionType {
 }
 
 /// 设备状态
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum DeviceStatus {
     Online,

--- a/src-tauri/src/document/commands.rs
+++ b/src-tauri/src/document/commands.rs
@@ -26,7 +26,7 @@ pub async fn db_get_documents(
     workspace_id: Uuid,
     db_state: State<'_, DbState>,
 ) -> AppResult<Vec<documents::Model>> {
-    let guard = db_state.workspace_db_for(window.label()).await?;
+    let guard = db_state.workspace_db_by_label(window.label()).await?;
     Ok(documents::Entity::find()
         .filter(documents::Column::WorkspaceId.eq(workspace_id))
         .all(guard.conn())
@@ -40,7 +40,7 @@ pub async fn db_upsert_document(
     db_state: State<'_, DbState>,
     identity: State<'_, IdentityState>,
 ) -> AppResult<documents::Model> {
-    let guard = db_state.workspace_db_for(window.label()).await?;
+    let guard = db_state.workspace_db_by_label(window.label()).await?;
     let db = guard.conn();
 
     if let Some(id) = input.id {
@@ -79,7 +79,7 @@ pub async fn delete_document_by_rel_path(
     db_state: State<'_, DbState>,
     identity: State<'_, IdentityState>,
 ) -> AppResult<()> {
-    let guard = db_state.workspace_db_for(window.label()).await?;
+    let guard = db_state.workspace_db_by_label(window.label()).await?;
     let db = guard.conn();
 
     let Some(doc) = documents::Entity::find()
@@ -133,7 +133,7 @@ pub async fn rename_document(
     db_state: State<'_, DbState>,
     ydoc_mgr: State<'_, YDocManager>,
 ) -> AppResult<()> {
-    let guard = db_state.workspace_db_for(window.label()).await?;
+    let guard = db_state.workspace_db_by_label(window.label()).await?;
     let db = guard.conn();
 
     let Some(doc) = documents::Entity::find()
@@ -163,7 +163,7 @@ pub async fn delete_documents_by_prefix(
     db_state: State<'_, DbState>,
     identity: State<'_, IdentityState>,
 ) -> AppResult<u64> {
-    let guard = db_state.workspace_db_for(window.label()).await?;
+    let guard = db_state.workspace_db_by_label(window.label()).await?;
     let db = guard.conn();
 
     let docs = documents::Entity::find()
@@ -223,7 +223,7 @@ pub async fn db_get_folders(
     workspace_id: Uuid,
     db_state: State<'_, DbState>,
 ) -> AppResult<Vec<folders::Model>> {
-    let guard = db_state.workspace_db_for(window.label()).await?;
+    let guard = db_state.workspace_db_by_label(window.label()).await?;
     Ok(folders::Entity::find()
         .filter(folders::Column::WorkspaceId.eq(workspace_id))
         .all(guard.conn())
@@ -237,7 +237,7 @@ pub async fn db_create_folder(
     db_state: State<'_, DbState>,
     identity: State<'_, IdentityState>,
 ) -> AppResult<folders::Model> {
-    let guard = db_state.workspace_db_for(window.label()).await?;
+    let guard = db_state.workspace_db_by_label(window.label()).await?;
 
     let model = folders::ActiveModel {
         workspace_id: Set(input.workspace_id),
@@ -256,7 +256,7 @@ pub async fn db_delete_folder(
     id: Uuid,
     db_state: State<'_, DbState>,
 ) -> AppResult<()> {
-    let guard = db_state.workspace_db_for(window.label()).await?;
+    let guard = db_state.workspace_db_by_label(window.label()).await?;
     let db = guard.conn();
 
     let child_folders = folders::Entity::find()

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -40,6 +40,12 @@ pub enum AppError {
     DocNotOpen(String),
 }
 
+impl AppError {
+    pub fn node_not_running() -> Self {
+        Self::Network("P2P node is not running".to_string())
+    }
+}
+
 /// 结构化序列化：为前端提供 `{ kind: "...", message: "..." }` 格式。
 /// 使用 `Cow` 避免对 String 变体的冗余 clone。
 impl Serialize for AppError {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -75,6 +75,7 @@ pub fn run() {
             pairing::commands::unpair_device,
             pairing::commands::get_nearby_devices,
             pairing::commands::list_devices,
+            pairing::commands::get_remote_workspaces,
             workspace::commands::open_settings_window,
             // Y.Doc 管理
             yjs::commands::open_ydoc,
@@ -132,7 +133,7 @@ pub fn run() {
             {
                 let ws_state = app.state::<workspace::state::WorkspaceState>();
                 let watcher_state = app.state::<fs::watcher::FsWatcherState>();
-                if let Some(info) = tauri::async_runtime::block_on(ws_state.get("main")) {
+                if let Some(info) = tauri::async_runtime::block_on(ws_state.get_by_label("main")) {
                     let ws_path = std::path::PathBuf::from(&info.path);
                     if let Err(e) =
                         fs::watcher::start_watching(app.handle(), "main", &ws_path, &watcher_state)

--- a/src-tauri/src/network/commands.rs
+++ b/src-tauri/src/network/commands.rs
@@ -48,6 +48,7 @@ pub async fn do_start_p2p_node(
     spawn_event_loop(
         receiver,
         app.clone(),
+        net_manager.client.clone(),
         net_manager.device_manager.clone(),
         net_manager.pairing_manager.clone(),
         cancel_token.clone(),

--- a/src-tauri/src/network/event_loop.rs
+++ b/src-tauri/src/network/event_loop.rs
@@ -2,15 +2,21 @@
 
 use std::sync::Arc;
 
+use sea_orm::{EntityTrait, PaginatorTrait};
 use swarm_p2p_core::event::NodeEvent;
+use swarm_p2p_core::libp2p::PeerId;
 use swarm_p2p_core::EventReceiver;
 use tauri::{AppHandle, Emitter, Manager};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::device::{DeviceFilter, DeviceManager};
+use crate::network::online::AppNetClient;
 use crate::pairing::PairingManager;
-use crate::protocol::AppRequest;
+use crate::protocol::{
+    AppRequest, AppResponse, WorkspaceMeta, WorkspaceRequest, WorkspaceResponse,
+};
+use crate::workspace::state::{DbState, WorkspaceState};
 
 /// Tauri 事件名常量
 pub mod events {
@@ -25,6 +31,7 @@ pub mod events {
 pub fn spawn_event_loop(
     mut receiver: EventReceiver<AppRequest>,
     app: AppHandle,
+    client: AppNetClient,
     device_manager: Arc<DeviceManager>,
     pairing_manager: Arc<PairingManager>,
     cancel_token: CancellationToken,
@@ -38,7 +45,7 @@ pub fn spawn_event_loop(
                 }
                 event = receiver.recv() => {
                     match event {
-                        Some(event) => handle_event(event, &app, &device_manager, &pairing_manager).await,
+                        Some(event) => handle_event(event, &app, &client, &device_manager, &pairing_manager).await,
                         None => {
                             info!("Event receiver closed, exiting event loop");
                             break;
@@ -53,6 +60,7 @@ pub fn spawn_event_loop(
 async fn handle_event(
     event: NodeEvent<AppRequest>,
     app: &AppHandle,
+    client: &AppNetClient,
     device_manager: &DeviceManager,
     pairing_manager: &PairingManager,
 ) {
@@ -132,7 +140,8 @@ async fn handle_event(
             pending_id,
             request,
         } => {
-            handle_inbound_request(app, pairing_manager, peer_id, pending_id, request);
+            handle_inbound_request(app, client, pairing_manager, peer_id, pending_id, request)
+                .await;
         }
 
         // ── GossipSub（未实现） ──
@@ -152,10 +161,11 @@ async fn handle_event(
 
 // ── 入站请求处理 ──
 
-fn handle_inbound_request(
+async fn handle_inbound_request(
     app: &AppHandle,
+    client: &AppNetClient,
     pairing_manager: &PairingManager,
-    peer_id: swarm_p2p_core::libp2p::PeerId,
+    peer_id: PeerId,
     pending_id: u64,
     request: AppRequest,
 ) {
@@ -180,10 +190,59 @@ fn handle_inbound_request(
                 &format!("{} 请求与您配对", pairing_req.os_info.hostname),
             );
         }
+
+        AppRequest::Workspace(WorkspaceRequest::ListWorkspaces) => {
+            info!("Received ListWorkspaces request from {peer_id}");
+            let response = build_workspace_list(app).await;
+            if let Err(e) = client
+                .send_response(pending_id, AppResponse::Workspace(response))
+                .await
+            {
+                warn!("Failed to send WorkspaceList response to {peer_id}: {e}");
+            }
+        }
+
         AppRequest::Sync(_) => {
             warn!("Received sync request from {peer_id} (pending_id={pending_id}), but sync handler not yet implemented");
         }
     }
+}
+
+/// 从 Tauri managed state 构建当前已打开工作区的元数据列表。
+async fn build_workspace_list(app: &AppHandle) -> WorkspaceResponse {
+    let empty = || WorkspaceResponse::WorkspaceList { workspaces: vec![] };
+
+    let Some(ws_state) = app.try_state::<WorkspaceState>() else {
+        return empty();
+    };
+    let Some(db_state) = app.try_state::<DbState>() else {
+        return empty();
+    };
+
+    let all_workspaces = ws_state.list_all().await;
+    let mut metas = Vec::with_capacity(all_workspaces.len());
+
+    for ws_info in &all_workspaces {
+        let doc_count = match db_state.workspace_db(&ws_info.id).await {
+            Ok(guard) => {
+                use entity::workspace::documents;
+                documents::Entity::find()
+                    .count(guard.conn())
+                    .await
+                    .unwrap_or(0) as u32
+            }
+            Err(_) => 0,
+        };
+
+        metas.push(WorkspaceMeta {
+            uuid: ws_info.id,
+            name: ws_info.name.clone(),
+            doc_count,
+            updated_at: ws_info.updated_at.timestamp_millis(),
+        });
+    }
+
+    WorkspaceResponse::WorkspaceList { workspaces: metas }
 }
 
 // ── 辅助函数 ──

--- a/src-tauri/src/network/mod.rs
+++ b/src-tauri/src/network/mod.rs
@@ -33,8 +33,6 @@ pub enum NodeStatus {
 
 /// 网络管理器：持有 P2P 节点所有运行时状态
 pub struct NetManager {
-    /// 供 sync 协议使用
-    #[expect(dead_code)]
     pub client: AppNetClient,
     pub device_manager: Arc<DeviceManager>,
     pub online_announcer: Arc<OnlineAnnouncer>,
@@ -102,18 +100,27 @@ impl NetManagerState {
     /// 获取 PairingManager。节点未运行时返回错误。
     pub async fn pairing(&self) -> crate::error::AppResult<Arc<crate::pairing::PairingManager>> {
         let guard = self.0.lock().await;
-        let manager = guard.as_ref().ok_or(crate::error::AppError::Network(
-            "P2P node is not running".to_string(),
-        ))?;
+        let manager = guard
+            .as_ref()
+            .ok_or_else(crate::error::AppError::node_not_running)?;
         Ok(manager.pairing_manager.clone())
+    }
+
+    /// 获取 NetClient。节点未运行时返回错误。
+    pub async fn client(&self) -> crate::error::AppResult<online::AppNetClient> {
+        let guard = self.0.lock().await;
+        let manager = guard
+            .as_ref()
+            .ok_or_else(crate::error::AppError::node_not_running)?;
+        Ok(manager.client.clone())
     }
 
     /// 获取 DeviceManager。节点未运行时返回错误。
     pub async fn devices(&self) -> crate::error::AppResult<Arc<DeviceManager>> {
         let guard = self.0.lock().await;
-        let manager = guard.as_ref().ok_or(crate::error::AppError::Network(
-            "P2P node is not running".to_string(),
-        ))?;
+        let manager = guard
+            .as_ref()
+            .ok_or_else(crate::error::AppError::node_not_running)?;
         Ok(manager.device_manager.clone())
     }
 }

--- a/src-tauri/src/pairing/commands.rs
+++ b/src-tauri/src/pairing/commands.rs
@@ -1,11 +1,18 @@
-use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Emitter, State};
+use std::time::Duration;
 
-use crate::device::{Device, DeviceFilter, DeviceListResult};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager, State};
+use tokio::task::JoinSet;
+use uuid::Uuid;
+
+use crate::device::{Device, DeviceFilter, DeviceListResult, DeviceStatus};
 use crate::error::AppResult;
 use crate::network::event_loop::events;
 use crate::network::NetManagerState;
-use crate::protocol::{OsInfo, PairingMethod};
+use crate::protocol::{
+    AppRequest, AppResponse, OsInfo, PairingMethod, WorkspaceRequest, WorkspaceResponse,
+};
+use crate::workspace::state::WorkspaceState;
 
 use super::code::PairingCodeInfo;
 use super::manager::PairedDeviceInfo;
@@ -17,6 +24,8 @@ pub struct DeviceByCodeResult {
     pub peer_id: String,
     pub os_info: OsInfo,
 }
+
+// ── 配对命令 ──
 
 #[tauri::command]
 pub async fn generate_pairing_code(
@@ -58,10 +67,7 @@ pub async fn request_pairing(
 
     if matches!(resp, crate::protocol::PairingResponse::Success) {
         let _ = app.emit(events::PAIRED_DEVICE_ADDED, ());
-        if let Ok(dm) = net_state.devices().await {
-            let devices = dm.get_devices(DeviceFilter::All);
-            let _ = app.emit(events::DEVICES_CHANGED, &devices);
-        }
+        emit_devices(&app, &net_state).await;
     }
 
     Ok(resp)
@@ -81,11 +87,7 @@ pub async fn respond_pairing_request(
         .await?;
     if let Some(info) = result {
         let _ = app.emit(events::PAIRED_DEVICE_ADDED, &info);
-        // 配对成功后 emit 完整设备列表，确保前端即时更新
-        if let Ok(dm) = net_state.devices().await {
-            let devices = dm.get_devices(DeviceFilter::All);
-            let _ = app.emit(events::DEVICES_CHANGED, &devices);
-        }
+        emit_devices(&app, &net_state).await;
     }
     Ok(())
 }
@@ -108,13 +110,11 @@ pub async fn unpair_device(
 ) -> AppResult<()> {
     net_state.pairing().await?.unpair(&peer_id).await?;
     let _ = app.emit(events::PAIRED_DEVICE_REMOVED, &peer_id);
-    // 取消配对后 emit 完整设备列表
-    if let Ok(dm) = net_state.devices().await {
-        let devices = dm.get_devices(DeviceFilter::All);
-        let _ = app.emit(events::DEVICES_CHANGED, &devices);
-    }
+    emit_devices(&app, &net_state).await;
     Ok(())
 }
+
+// ── 设备查询命令 ──
 
 #[tauri::command]
 pub async fn list_devices(
@@ -133,11 +133,110 @@ pub async fn get_nearby_devices(net_state: State<'_, NetManagerState>) -> AppRes
         Ok(dm) => dm,
         Err(_) => return Ok(Vec::new()),
     };
-
-    let nearby: Vec<Device> = dm
+    Ok(dm
         .get_devices(DeviceFilter::Connected)
         .into_iter()
         .filter(|d| !d.is_paired)
+        .collect())
+}
+
+// ── 工作区列表交换 ──
+
+/// 远程工作区信息（合并来源 peer 信息）
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteWorkspaceInfo {
+    pub uuid: Uuid,
+    pub name: String,
+    pub doc_count: u32,
+    pub updated_at: i64,
+    pub peer_id: String,
+    pub peer_name: String,
+    pub is_local: bool,
+}
+
+/// 并发查询所有已配对在线 peer 的工作区列表，标记 is_local。
+#[tauri::command]
+pub async fn get_remote_workspaces(
+    app: AppHandle,
+    net_state: State<'_, NetManagerState>,
+) -> AppResult<Vec<RemoteWorkspaceInfo>> {
+    let client = net_state.client().await?;
+    let dm = net_state.devices().await?;
+
+    let paired_online: Vec<Device> = dm
+        .get_devices(DeviceFilter::Paired)
+        .into_iter()
+        .filter(|d| d.status == DeviceStatus::Online)
         .collect();
-    Ok(nearby)
+
+    if paired_online.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // 并发向所有 peer 发送 ListWorkspaces，5s 超时
+    let mut tasks = JoinSet::new();
+    for device in &paired_online {
+        let peer_id_str = device.peer_id.clone();
+        let peer_name = device.hostname.clone();
+        let client = client.clone();
+        tasks.spawn(async move {
+            let Ok(peer_id) = peer_id_str.parse::<swarm_p2p_core::libp2p::PeerId>() else {
+                return (peer_id_str, peer_name, None);
+            };
+            let result = tokio::time::timeout(
+                Duration::from_secs(5),
+                client.send_request(
+                    peer_id,
+                    AppRequest::Workspace(WorkspaceRequest::ListWorkspaces),
+                ),
+            )
+            .await;
+            let workspaces = match result {
+                Ok(Ok(AppResponse::Workspace(WorkspaceResponse::WorkspaceList { workspaces }))) => {
+                    Some(workspaces)
+                }
+                _ => None,
+            };
+            (peer_id_str, peer_name, workspaces)
+        });
+    }
+
+    // 收集结果
+    let local_uuids: std::collections::HashSet<Uuid> = match app.try_state::<WorkspaceState>() {
+        Some(ws_state) => ws_state
+            .list_all()
+            .await
+            .into_iter()
+            .map(|info| info.id)
+            .collect(),
+        None => std::collections::HashSet::new(),
+    };
+
+    let mut results = Vec::new();
+    while let Some(Ok((peer_id, peer_name, Some(workspaces)))) = tasks.join_next().await {
+        for ws in workspaces {
+            results.push(RemoteWorkspaceInfo {
+                is_local: local_uuids.contains(&ws.uuid),
+                uuid: ws.uuid,
+                name: ws.name,
+                doc_count: ws.doc_count,
+                updated_at: ws.updated_at,
+                peer_id: peer_id.clone(),
+                peer_name: peer_name.clone(),
+            });
+        }
+    }
+
+    Ok(results)
+}
+
+// ── Helpers ──
+
+/// 配对变更后 emit 完整设备列表，确保前端即时更新。
+async fn emit_devices(app: &AppHandle, net_state: &NetManagerState) {
+    if let Ok(dm) = net_state.devices().await {
+        let devices = dm.get_devices(DeviceFilter::All);
+        let _ = app.emit(events::DEVICES_CHANGED, &devices);
+    }
 }

--- a/src-tauri/src/protocol/mod.rs
+++ b/src-tauri/src/protocol/mod.rs
@@ -92,6 +92,7 @@ impl Default for OsInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum AppRequest {
     Pairing(PairingRequest),
+    Workspace(WorkspaceRequest),
     Sync(SyncRequest),
 }
 
@@ -99,7 +100,32 @@ pub enum AppRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum AppResponse {
     Pairing(PairingResponse),
+    Workspace(WorkspaceResponse),
     Sync(SyncResponse),
+}
+
+// ── 工作区子协议 ──
+
+/// 工作区请求：资源发现阶段。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum WorkspaceRequest {
+    /// 查询对方当前已打开的工作区列表
+    ListWorkspaces,
+}
+
+/// 工作区响应。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum WorkspaceResponse {
+    WorkspaceList { workspaces: Vec<WorkspaceMeta> },
+}
+
+/// 工作区元数据，用于列表交换。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceMeta {
+    pub uuid: Uuid,
+    pub name: String,
+    pub doc_count: u32,
+    pub updated_at: i64,
 }
 
 // ── 同步子协议 ──
@@ -236,6 +262,7 @@ mod tests {
                 timestamp: 1234567890,
                 method: PairingMethod::Direct,
             }),
+            AppRequest::Workspace(WorkspaceRequest::ListWorkspaces),
         ];
 
         for req in requests {
@@ -268,6 +295,14 @@ mod tests {
             AppResponse::Pairing(PairingResponse::Success),
             AppResponse::Pairing(PairingResponse::Refused {
                 reason: PairingRefuseReason::CodeExpired,
+            }),
+            AppResponse::Workspace(WorkspaceResponse::WorkspaceList {
+                workspaces: vec![WorkspaceMeta {
+                    uuid: Uuid::now_v7(),
+                    name: "Test Workspace".to_string(),
+                    doc_count: 42,
+                    updated_at: 1234567890,
+                }],
             }),
         ];
 

--- a/src-tauri/src/workspace/commands.rs
+++ b/src-tauri/src/workspace/commands.rs
@@ -119,10 +119,12 @@ async fn bind_workspace_to_window(
         }
     }
 
-    db_state.insert_workspace_db(label, conn).await;
+    db_state
+        .insert_workspace_db(label, workspace.id, conn)
+        .await;
 
     let info = WorkspaceInfo::from_model(workspace, path);
-    ws_state.insert(label, info.clone()).await;
+    ws_state.bind(label, info.clone()).await;
 
     let dir_name = workspace_name_from_path(ws_path);
     {
@@ -206,7 +208,7 @@ pub async fn get_workspace_info(
     window: tauri::Window,
     ws_state: State<'_, WorkspaceState>,
 ) -> AppResult<Option<WorkspaceInfo>> {
-    Ok(ws_state.get(window.label()).await)
+    Ok(ws_state.get_by_label(window.label()).await)
 }
 
 #[tauri::command]

--- a/src-tauri/src/workspace/mod.rs
+++ b/src-tauri/src/workspace/mod.rs
@@ -5,7 +5,6 @@ pub mod db;
 pub mod identity;
 pub mod state;
 
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 use entity::workspace::workspaces;
@@ -24,18 +23,18 @@ pub fn init(app: &tauri::AppHandle) -> Result<(), AppError> {
     });
     let devices_db = devices_result?;
 
-    let mut workspace_dbs = HashMap::new();
-    let mut workspace_infos = HashMap::new();
+    let db_state = DbState::new(devices_db);
+    let ws_state = WorkspaceState::new();
 
-    if let Some(conn) = workspace_db {
-        workspace_dbs.insert("main".to_owned(), conn);
-    }
-    if let Some(info) = workspace_info {
-        workspace_infos.insert("main".to_owned(), info);
+    if let (Some(conn), Some(info)) = (workspace_db, workspace_info) {
+        tauri::async_runtime::block_on(async {
+            db_state.insert_workspace_db("main", info.id, conn).await;
+            ws_state.bind("main", info).await;
+        });
     }
 
-    app.manage(DbState::new(devices_db, workspace_dbs));
-    app.manage(WorkspaceState::new(workspace_infos));
+    app.manage(db_state);
+    app.manage(ws_state);
 
     Ok(())
 }
@@ -54,7 +53,7 @@ pub async fn cleanup_window(
 
     crate::fs::watcher::stop_watching(label, watcher_state);
 
-    if ws_state.remove(label).await {
+    if ws_state.unbind_by_label(label).await {
         tracing::info!("Cleaned up WorkspaceInfo for window '{label}'");
     }
     if db_state.remove_workspace_db(label).await {

--- a/src-tauri/src/workspace/state.rs
+++ b/src-tauri/src/workspace/state.rs
@@ -1,116 +1,154 @@
 //! 工作区相关的 Tauri State 类型。
+//!
+//! 主键为 workspace UUID，window label 作为辅助索引。
 
 use std::collections::HashMap;
 
 use sea_orm::DatabaseConnection;
 use tokio::sync::RwLock;
+use uuid::Uuid;
 
 use super::commands::WorkspaceInfo;
 use crate::error::AppError;
 
-/// 数据库状态：全局 devices.db + per-window 工作区数据库连接。
+// ── DbState ──
+
+/// 数据库状态：全局 devices.db + per-workspace 数据库连接。
 pub struct DbState {
     pub devices_db: DatabaseConnection,
-    workspace_dbs: RwLock<HashMap<String, DatabaseConnection>>,
+    /// 主索引：workspace UUID → DatabaseConnection
+    workspace_dbs: RwLock<HashMap<Uuid, DatabaseConnection>>,
+    /// 辅助索引：window label → workspace UUID
+    label_to_uuid: RwLock<HashMap<String, Uuid>>,
 }
 
 impl DbState {
-    pub fn new(
-        devices_db: DatabaseConnection,
-        workspace_dbs: HashMap<String, DatabaseConnection>,
-    ) -> Self {
+    pub fn new(devices_db: DatabaseConnection) -> Self {
         Self {
             devices_db,
-            workspace_dbs: RwLock::new(workspace_dbs),
+            workspace_dbs: RwLock::new(HashMap::new()),
+            label_to_uuid: RwLock::new(HashMap::new()),
         }
     }
 
-    /// 获取指定窗口的工作区数据库连接。
-    pub async fn workspace_db_for(&self, label: &str) -> Result<WorkspaceDbGuard<'_>, AppError> {
+    /// 通过 UUID 获取工作区数据库连接。
+    pub async fn workspace_db(&self, uuid: &Uuid) -> Result<WorkspaceDbGuard<'_>, AppError> {
         let guard = self.workspace_dbs.read().await;
-        if !guard.contains_key(label) {
+        if !guard.contains_key(uuid) {
             return Err(AppError::NoWorkspaceDb);
         }
-        Ok(WorkspaceDbGuard {
-            guard,
-            label: label.to_owned(),
-        })
+        Ok(WorkspaceDbGuard { guard, key: *uuid })
     }
 
-    /// 注册指定窗口的工作区数据库连接。
-    pub async fn insert_workspace_db(&self, label: &str, conn: DatabaseConnection) {
-        self.workspace_dbs
+    /// 通过 window label 获取工作区数据库连接（Tauri 命令便捷方法）。
+    pub async fn workspace_db_by_label(
+        &self,
+        label: &str,
+    ) -> Result<WorkspaceDbGuard<'_>, AppError> {
+        let uuid = self.resolve_uuid(label).await?;
+        self.workspace_db(&uuid).await
+    }
+
+    /// 注册工作区数据库连接。
+    pub async fn insert_workspace_db(&self, label: &str, uuid: Uuid, conn: DatabaseConnection) {
+        self.workspace_dbs.write().await.insert(uuid, conn);
+        self.label_to_uuid
             .write()
             .await
-            .insert(label.to_owned(), conn);
+            .insert(label.to_owned(), uuid);
     }
 
-    /// 移除指定窗口的工作区数据库连接（drop 即关闭）。
+    /// 移除工作区数据库连接。
     pub async fn remove_workspace_db(&self, label: &str) -> bool {
-        self.workspace_dbs.write().await.remove(label).is_some()
-    }
-}
-
-/// Per-window 工作区信息。
-pub struct WorkspaceState {
-    infos: RwLock<HashMap<String, WorkspaceInfo>>,
-}
-
-impl WorkspaceState {
-    pub fn new(infos: HashMap<String, WorkspaceInfo>) -> Self {
-        Self {
-            infos: RwLock::new(infos),
-        }
+        let Some(uuid) = self.label_to_uuid.write().await.remove(label) else {
+            return false;
+        };
+        self.workspace_dbs.write().await.remove(&uuid).is_some()
     }
 
-    /// 获取指定窗口的工作区信息。
-    pub async fn get(&self, label: &str) -> Option<WorkspaceInfo> {
-        self.infos.read().await.get(label).cloned()
-    }
-
-    /// 注册指定窗口的工作区信息。
-    pub async fn insert(&self, label: &str, info: WorkspaceInfo) {
-        self.infos.write().await.insert(label.to_owned(), info);
-    }
-
-    /// 移除指定窗口的工作区信息。
-    pub async fn remove(&self, label: &str) -> bool {
-        self.infos.write().await.remove(label).is_some()
-    }
-
-    /// 查找已打开指定路径的窗口 label。
-    pub async fn find_label_by_path(&self, path: &str) -> Option<String> {
-        self.infos
-            .read()
-            .await
-            .iter()
-            .find(|(_, info)| info.path == path)
-            .map(|(label, _)| label.clone())
-    }
-
-    /// 获取指定窗口的工作区路径。
-    pub async fn workspace_path_for(&self, label: &str) -> Result<String, AppError> {
-        self.infos
+    async fn resolve_uuid(&self, label: &str) -> Result<Uuid, AppError> {
+        self.label_to_uuid
             .read()
             .await
             .get(label)
-            .map(|ws| ws.path.clone())
-            .ok_or(AppError::NoWorkspaceOpen)
+            .copied()
+            .ok_or(AppError::NoWorkspaceDb)
     }
 }
 
-/// Guard that holds a read lock on the workspace_dbs HashMap and provides
-/// access to a specific window's database connection.
+/// Guard that holds a read lock on workspace_dbs and provides access to a DB connection.
 pub struct WorkspaceDbGuard<'a> {
-    guard: tokio::sync::RwLockReadGuard<'a, HashMap<String, DatabaseConnection>>,
-    label: String,
+    guard: tokio::sync::RwLockReadGuard<'a, HashMap<Uuid, DatabaseConnection>>,
+    key: Uuid,
 }
 
 impl WorkspaceDbGuard<'_> {
     pub fn conn(&self) -> &DatabaseConnection {
-        // SAFETY: label existence was verified in workspace_db_for before constructing this guard
         self.guard
-            .get(&self.label)
-            .expect("label was checked in workspace_db_for")
+            .get(&self.key)
+            .expect("key was checked before constructing guard")
+    }
+}
+
+// ── WorkspaceState ──
+
+/// Per-workspace 工作区信息。主键为 UUID。
+pub struct WorkspaceState {
+    /// 主索引：workspace UUID → WorkspaceInfo
+    workspaces: RwLock<HashMap<Uuid, WorkspaceInfo>>,
+    /// 辅助索引：window label → workspace UUID
+    bindings: RwLock<HashMap<String, Uuid>>,
+}
+
+impl WorkspaceState {
+    pub fn new() -> Self {
+        Self {
+            workspaces: RwLock::new(HashMap::new()),
+            bindings: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// 绑定工作区到窗口（初始化和运行时共用）
+    pub async fn bind(&self, label: &str, info: WorkspaceInfo) {
+        let uuid = info.id;
+        self.workspaces.write().await.insert(uuid, info);
+        self.bindings.write().await.insert(label.to_owned(), uuid);
+    }
+
+    /// 解绑窗口
+    pub async fn unbind_by_label(&self, label: &str) -> bool {
+        let Some(uuid) = self.bindings.write().await.remove(label) else {
+            return false;
+        };
+        self.workspaces.write().await.remove(&uuid).is_some()
+    }
+
+    /// 通过 label 获取工作区信息（Tauri 命令用）
+    pub async fn get_by_label(&self, label: &str) -> Option<WorkspaceInfo> {
+        let uuid = self.bindings.read().await.get(label).copied()?;
+        self.workspaces.read().await.get(&uuid).cloned()
+    }
+
+    /// 获取所有已打开的工作区信息（同步层用）
+    pub async fn list_all(&self) -> Vec<WorkspaceInfo> {
+        self.workspaces.read().await.values().cloned().collect()
+    }
+
+    /// 查找已打开指定路径的窗口 label
+    pub async fn find_label_by_path(&self, path: &str) -> Option<String> {
+        let workspaces = self.workspaces.read().await;
+        let bindings = self.bindings.read().await;
+        bindings
+            .iter()
+            .find(|(_, uuid)| workspaces.get(uuid).is_some_and(|info| info.path == path))
+            .map(|(label, _)| label.clone())
+    }
+
+    /// 获取指定窗口的工作区路径
+    pub async fn workspace_path_for(&self, label: &str) -> Result<String, AppError> {
+        self.get_by_label(label)
+            .await
+            .map(|ws| ws.path)
+            .ok_or(AppError::NoWorkspaceOpen)
     }
 }

--- a/src-tauri/src/yjs/manager.rs
+++ b/src-tauri/src/yjs/manager.rs
@@ -178,7 +178,7 @@ impl YDocManager {
 
         // Concurrency-safe upsert: INSERT OR IGNORE (UNIQUE constraint deduplicates),
         // then SELECT to get the winning row's UUID.
-        let guard = db_state.workspace_db_for(label).await?;
+        let guard = db_state.workspace_db_by_label(label).await?;
         let db = guard.conn();
 
         // Try inserting first — if another call already inserted, IGNORE silently.
@@ -499,7 +499,7 @@ impl YDocManager {
         entry._last_write_ms.store(now_ms(), Ordering::Release);
 
         let db_state = app.state::<DbState>();
-        let guard = db_state.workspace_db_for(label).await?;
+        let guard = db_state.workspace_db_by_label(label).await?;
 
         if let Some(existing) = documents::Entity::find_by_id(entry.doc_db_id)
             .one(guard.conn())

--- a/src/commands/pairing.ts
+++ b/src/commands/pairing.ts
@@ -55,6 +55,22 @@ export interface DeviceListResult {
 
 export type DeviceFilter = "all" | "connected" | "paired";
 
+// ── 工作区列表交换 ──
+
+export interface RemoteWorkspaceInfo {
+  uuid: string;
+  name: string;
+  docCount: number;
+  updatedAt: number;
+  peerId: string;
+  peerName: string;
+  isLocal: boolean;
+}
+
+export async function getRemoteWorkspaces(): Promise<RemoteWorkspaceInfo[]> {
+  return invoke("get_remote_workspaces");
+}
+
 export async function listDevices(filter?: DeviceFilter): Promise<DeviceListResult> {
   return invoke("list_devices", { filter });
 }


### PR DESCRIPTION
Refactor runtime state to use workspace UUID as primary key:
- WorkspaceState/DbState: UUID primary index + label secondary bindings
- All consumers adapted (document, yjs, workspace commands)

Add P2P workspace list exchange protocol:
- New AppRequest::Workspace(ListWorkspaces) / AppResponse::Workspace(WorkspaceList)
- Inbound: auto-respond with open workspaces (doc count from DB)
- Outbound: get_remote_workspaces command with JoinSet concurrent query, 5s timeout, is_local marking
- NetClient passed through event loop for send_response

Code quality improvements:
- Extract emit_devices helper, AppError::node_not_running()
- JoinSet replaces Vec<JoinHandle> for concurrent tasks
- let-else patterns for early returns
- Deduplicate init/bind methods

Closes #46