### PR TITLE
chore: switch host editor consumption to @swarmnote/editor-core via pnpm link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,17 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      - name: Clone editor-core sibling
+        run: git clone --depth=1 https://github.com/swarm-apps/swarmnote-editor.git ${{ github.workspace }}/../swarmnote-editor
+
+      - name: Build editor-core sibling
+        working-directory: ${{ github.workspace }}/../swarmnote-editor
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm -r build
+
+      - name: Install host deps (link override resolves to sibling)
+        run: pnpm install --frozen-lockfile
 
       - name: Biome CI
         run: pnpm lint:ci

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "libs"]
 	path = libs
 	url = https://github.com/swarm-apps/swarm-p2p.git
-[submodule "packages/editor"]
-	path = packages/editor
-	url = https://github.com/swarm-apps/swarmnote-editor.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 知识库主题：
 
 - `dev-notes/knowledge/theme-and-styling.md` — shadcn/ui、主题变量、窗口装饰
-- `dev-notes/knowledge/editor.md` — CM6、Y.Doc、y-codemirror.next、@swarmnote/editor submodule
+- `dev-notes/knowledge/editor.md` — CM6、Y.Doc、y-codemirror.next、`@swarmnote/editor-core` 外部 sibling 仓 + pnpm link 接入
 - `dev-notes/knowledge/rust-backend.md` — Tauri command、SeaORM、YDocManager、P2P
 - `dev-notes/knowledge/toolchain.md` — Biome、Lefthook、Lingui、Cargo workspace、Vite
 
@@ -20,8 +20,13 @@ SwarmNote is a decentralized, local-first, peer-to-peer note-taking app built wi
 ## Development Commands
 
 ```bash
-# First-time setup: init git submodule (libs/core) + install deps
+# First-time setup: clone with submodule (libs/core), build sibling editor-core, then install host
 git submodule update --init --recursive
+
+# Editor core lives in a separate sibling repo, linked via pnpm.overrides → ../swarmnote-editor
+git clone https://github.com/swarm-apps/swarmnote-editor.git ../swarmnote-editor
+(cd ../swarmnote-editor && pnpm install && pnpm -r build)
+
 pnpm install
 
 # Launch full Tauri desktop app (starts frontend + Rust backend)

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ graph LR
 ```mermaid
 graph TB
     Frontend["前端 — React 19 + TypeScript<br/>shadcn/ui · Tailwind 4 · TanStack Router · Zustand"]
-    Editor["@swarmnote/editor<br/>CodeMirror 6 + y-codemirror.next + KaTeX"]
+    Editor["@swarmnote/editor-core<br/>CodeMirror 6 + y-codemirror.next + KaTeX"]
 
     Tauri["平台层 — Tauri 2 (src-tauri/)<br/>Tauri Commands · 文件监听 · 系统托盘 · OS Keychain"]
 
@@ -195,7 +195,7 @@ graph TB
 | 层级 | 技术 |
 |------|------|
 | 前端 | React 19 · TypeScript 5.8 · Vite 7 |
-| 编辑器 | CodeMirror 6 + `@codemirror/lang-markdown` + `y-codemirror.next` + KaTeX（封装在 `@swarmnote/editor` 包） |
+| 编辑器 | CodeMirror 6 + `@codemirror/lang-markdown` + `y-codemirror.next` + KaTeX（封装在独立仓 [`@swarmnote/editor-core`](https://github.com/swarm-apps/swarmnote-editor) 包，本地通过 pnpm link 接入） |
 | UI 组件 | shadcn/ui · Radix · Tailwind CSS 4 · Lucide |
 | 状态管理 | Zustand 5（9 个 Store · 部分通过 `tauri-plugin-store` 持久化） |
 | 路由 | TanStack Router（文件系统路由） |
@@ -217,14 +217,15 @@ graph TB
 swarmnote/
 ├── src/                       # 前端源码
 ├── src-tauri/                 # 平台层（Tauri 命令处理 / OS 集成）
-├── packages/
-│   └── editor/                # @swarmnote/editor —— CodeMirror 6 编辑器
 ├── crates/
 │   ├── core/                  # swarmnote-core —— 平台无关核心 (桌面 + 移动共享)
 │   ├── entity/                # SeaORM entity 定义
 │   └── migration/             # 数据库迁移
 ├── libs/core/                 # swarm-p2p-core (Git submodule —— P2P 网络层)
 └── docs/                      # Astro + Starlight 文档站
+
+# 编辑器核心是独立仓，通过 pnpm link --global 接入：
+../swarmnote-editor/           # @swarmnote/editor-core (https://github.com/swarm-apps/swarmnote-editor)
 ```
 
 </details>
@@ -240,11 +241,15 @@ swarmnote/
 ### 构建步骤
 
 ```bash
-# 克隆仓库（含 swarm-p2p-core 子模块）
+# 1. 克隆 SwarmNote 主仓（含 swarm-p2p-core 子模块）
 git clone --recurse-submodules https://github.com/swarm-apps/SwarmNote.git
 cd SwarmNote
 
-# 安装依赖
+# 2. 在同级目录 clone & 构建 swarmnote-editor（编辑器内核）
+git clone https://github.com/swarm-apps/swarmnote-editor.git ../swarmnote-editor
+(cd ../swarmnote-editor && pnpm install && pnpm -r build)
+
+# 3. 安装主仓依赖（`pnpm.overrides` 已经把 @swarmnote/editor-core 指向 sibling 仓的 dist）
 pnpm install
 
 # 桌面端开发（前端 + Rust 后端）
@@ -257,6 +262,18 @@ pnpm tauri build
 pnpm lint
 cd src-tauri && cargo clippy -- -D warnings
 ```
+
+### 编辑器联调（开发 swarmnote-editor 同时运行主仓）
+
+```bash
+# 在 swarmnote-editor 仓启动 watch（每次改源码自动重建 dist）
+(cd ../swarmnote-editor && pnpm dev)
+
+# 主仓另开终端跑 dev（Vite HMR 会因 dist 变化自动 reload）
+pnpm tauri dev
+```
+
+主仓 `package.json` 的 `pnpm.overrides` 把 `@swarmnote/editor-core` 锚定到 `../swarmnote-editor/packages/editor-core`——所以 sibling 必须 clone 到主仓同级目录。未来 `@swarmnote/editor-core` 发到 npm 后会移除这条 override，改用版本号。
 
 ## Swarm 生态
 

--- a/dev-notes/knowledge/editor.md
+++ b/dev-notes/knowledge/editor.md
@@ -6,33 +6,49 @@
 
 调用链：`React (NoteEditor) → createEditor() → CM6 EditorView → ySync extension ↔ Y.Text`
 
-- 编辑器核心：`packages/editor/`（submodule：`swarm-apps/swarmnote-editor`），桌面端和移动端共享
+- 编辑器内核：`@swarmnote/editor-core`（独立仓 [`swarm-apps/swarmnote-editor`](https://github.com/swarm-apps/swarmnote-editor)，pnpm workspace monorepo），桌面端和移动端共享
 - 桌面端 React 容器：`src/components/editor/NoteEditor.tsx`
 - 文档大纲：`src/components/editor/DocumentOutline.tsx`（基于 `extractHeadings`）
 
-## @swarmnote/editor 是 git submodule
+## @swarmnote/editor-core 是外部 sibling 仓 + pnpm link
 
-`packages/editor/` 有独立 Git 仓库。修改编辑器核心代码的流程：
+`@swarmnote/editor-core` 不再是主仓的 submodule，而是独立 repo `swarm-apps/swarmnote-editor`。本地通过 `pnpm.overrides` 把包名解析到 sibling 路径 `../swarmnote-editor/packages/editor-core`，所以 sibling 必须 clone 到与 SwarmNote 同级目录。
+
+### Local development with editor-core
+
+修改编辑器内核代码的流程：
 
 ```bash
-# 1. 在 submodule 内修改、提交、推送
-cd packages/editor
-git add .
-git commit -m "feat: ..."
-git push origin main
+# 1. 在 sibling 仓启动 watch（每次改源码自动 rebuild dist）
+cd ../swarmnote-editor
+pnpm dev    # tsdown --watch on @swarmnote/editor-core
 
-# 2. 回到主仓库，更新 submodule 引用
-cd ../..
-git add packages/editor
-git commit -m "chore: update editor submodule"
+# 2. 主仓另开终端跑 dev，dist 变化会自动反映
+cd ../SwarmNote
+pnpm tauri dev
+```
+
+提交流程：
+
+```bash
+# 1. 在 sibling 仓内分支提交、push、开 PR
+cd ../swarmnote-editor
+git checkout -b feat/...
+git add . && git commit -m "feat: ..."
+git push -u origin feat/...
+# → swarm-apps/swarmnote-editor PR
+
+# 2. sibling PR 合并后，主仓的 link target 即指向新版 main，无需主仓任何改动
+#    （未来 npm 化后，主仓 package.json 改版本号 + 删除 pnpm.overrides 即可切换）
 ```
 
 **关键注意**：
-- 主仓库只记录 submodule 指向的 commit hash。**子模块 push 必须先于主仓库 push**，否则远端 submodule 指针指向不存在的 commit
-- 不要在主仓库层面直接改 `packages/editor/` 内的文件然后在主仓库提交——那样不会推到 submodule 仓库
-- 拉取最新 submodule：`git submodule update --remote packages/editor`
 
-**相关文件**：`packages/editor/`（submodule）、`.gitmodules`
+- sibling 必须 clone 到 `../swarmnote-editor`（package.json 的 `pnpm.overrides` 锚定该相对路径）
+- 主仓不再有 submodule 链路——把"先 push submodule 再 bump 主仓 pointer"那套规则忘掉
+- CI 通过 `git clone` 把 sibling 拉到 `${{ github.workspace }}/../swarmnote-editor` 然后 build；主仓 install 自动用 link
+
+**相关文件**：主仓 `package.json::pnpm.overrides`、`.github/workflows/ci.yml`、sibling 仓 `packages/editor-core/`
 
 ## Y.Doc 关键约束
 
@@ -82,7 +98,7 @@ const field = StateField.define<DecorationSet>({
 
 图片、代码块、表格这些跨行 widget 都遵循这个模式。
 
-**相关文件**：`packages/editor/src/extensions/renderBlockImages.ts`、`renderBlockCode.ts`、`renderBlockTables.ts`
+**相关文件**：`../swarmnote-editor/packages/editor-core/src/extensions/renderBlockImages.ts`、`renderBlockCode.ts`、`renderBlockTables.ts`
 
 ### Collaboration 模式初始化时必须 seed 文档
 
@@ -96,7 +112,7 @@ if (collaboration) {
 }
 ```
 
-**相关文件**：`packages/editor/src/createEditor.ts`
+**相关文件**：`../swarmnote-editor/packages/editor-core/src/createEditor.ts`
 
 ### 禁用 EDIT_CONTEXT
 
@@ -108,7 +124,7 @@ Android WebView（移动端场景）上必须禁用，桌面端也一并禁用�
 
 不要删掉这行。
 
-**相关文件**：`packages/editor/src/createEditor.ts`
+**相关文件**：`../swarmnote-editor/packages/editor-core/src/createEditor.ts`
 
 ### Ctrl+B 快捷键冲突
 
@@ -142,7 +158,7 @@ const imageResolver = useCallback(
 );
 ```
 
-**相关文件**：`src/components/editor/NoteEditor.tsx`、`packages/editor/src/extensions/renderBlockImages.ts`
+**相关文件**：`src/components/editor/NoteEditor.tsx`、`../swarmnote-editor/packages/editor-core/src/extensions/renderBlockImages.ts`
 
 ### P2P 媒体到达后刷新 widget
 
@@ -165,19 +181,19 @@ const imageResolver = useCallback(
 
 光标进入图片范围（block 是整行，inline 是 `[node.from, node.to]`）→ 跳过 emission，露出原始 markdown 源码可编辑。
 
-**相关文件**：`packages/editor/src/extensions/renderBlockImages.ts`
+**相关文件**：`../swarmnote-editor/packages/editor-core/src/extensions/renderBlockImages.ts`
 
 ### Lezer `Image.parent === Link` = 图片链接
 
 `[![alt](img)](href)` 在 lezer 树里是 `Link > Image`。`getLinkedImageInfo()` 用 `parent.getChild('URL')`/`parent.getChild('LinkTitle')` 提取链接 href + title（不要手写 nextSibling 走，已踩坑过）。命中后用 Link 的整个范围作 `Decoration.replace`，避免外层 `[` 和 `](url)` 露出。widget 加底部右下/右上的外链按钮，Ctrl/Cmd-click 图片或点按钮触发跳转。
 
-**相关文件**：`packages/editor/src/extensions/renderBlockImages.ts::getLinkedImageInfo`
+**相关文件**：`../swarmnote-editor/packages/editor-core/src/extensions/renderBlockImages.ts::getLinkedImageInfo`
 
 ### 跳转链接：走 `editorEventCallback` Facet 派发 LinkOpen
 
 Tauri webview 默认安全策略屏蔽 `window.open`——所有链接打开都走 `editorEventCallback` Facet 派发 `EditorEventType.LinkOpen` 事件，由 host (`NoteEditor.tsx::onEvent`) 调 `@tauri-apps/plugin-opener` 的 `openUrl()`。markdown link 的 ctrl-click、图片链接按钮、HTML `<a>` 内嵌链接 ctrl-click 全部统一这条管道。
 
-**相关文件**：`packages/editor/src/extensions/renderBlockImages.ts::dispatchLinkOpen`、`packages/editor/src/extensions/renderRawHtml.ts::attachLinkInterceptor`、`src/components/editor/NoteEditor.tsx::onEvent` 的 `LinkOpen` 分支
+**相关文件**：`../swarmnote-editor/packages/editor-core/src/extensions/renderBlockImages.ts::dispatchLinkOpen`、`../swarmnote-editor/packages/editor-core/src/extensions/renderRawHtml.ts::attachLinkInterceptor`、`src/components/editor/NoteEditor.tsx::onEvent` 的 `LinkOpen` 分支
 
 ## 原生 HTML 渲染（renderRawHtml.ts）
 
@@ -188,11 +204,11 @@ Tauri webview 默认安全策略屏蔽 `window.open`——所有链接打开都�
 - `<br>` 包装的 span 必须 `display: inline`（不是 inline-block），否则 `<br>` 的换行被困在 wrapper 内不传播到外层段落
 - 表格单元格 `<br>`：`renderInlineMarkdown.ts` 用 PUA 占位符在 escapeHtml 之前抽出 `<br>`，结尾还原——不抽出会被 `&lt;br&gt;` 转义掉
 
-**相关文件**：`packages/editor/src/extensions/renderRawHtml.ts`、`packages/editor/src/utils/renderInlineMarkdown.ts`
+**相关文件**：`../swarmnote-editor/packages/editor-core/src/extensions/renderRawHtml.ts`、`../swarmnote-editor/packages/editor-core/src/utils/renderInlineMarkdown.ts`
 
 ## Admonition / Callout
 
-GFM `> [!NOTE]` 与 Obsidian `> **NOTE**` 双语法兼容（`packages/editor/src/extensions/admonition/`）。Obsidian 风格圆角填充盒，Lucide SVG 图标 + label，cursor 进入块内任意位置 → 整块切源码模式。
+GFM `> [!NOTE]` 与 Obsidian `> **NOTE**` 双语法兼容（`../swarmnote-editor/packages/editor-core/src/extensions/admonition/`）。Obsidian 风格圆角填充盒，Lucide SVG 图标 + label，cursor 进入块内任意位置 → 整块切源码模式。
 
 ### 关键约束
 
@@ -201,7 +217,7 @@ GFM `> [!NOTE]` 与 Obsidian `> **NOTE**` 双语法兼容（`packages/editor/src
 3. **标题 widget 用 `block: true` Decoration.replace**——之前用 inline replace + line decoration 重叠，CodeMirror reconciliation 在「装饰从无到有再到无」循环中可能掉装饰。block widget 自带完整 DOM（含 bg/圆角），独立行，不依赖 line decoration。
 4. **行号迭代用 `state.doc.line(n)`**——之前用 `rawText.split(/\n>/)` + cursor offset 推导每行偏移，在 CJK + 行边界 `\n` 上有 off-by-one。直接 `lineAt(node.from).number` 起、`lineAt(node.to).number` 止逐号取行最稳。
 
-**相关文件**：`packages/editor/src/extensions/admonition/admonitionExtension.ts`、`presets.ts`（Lucide SVG icons）
+**相关文件**：`../swarmnote-editor/packages/editor-core/src/extensions/admonition/admonitionExtension.ts`、`presets.ts`（Lucide SVG icons）
 
 ## 大纲提取
 
@@ -211,16 +227,17 @@ GFM `> [!NOTE]` 与 Obsidian `> **NOTE**` 双语法兼容（`packages/editor/src
 - 返回 `HeadingItem[]`：`{ level, text, offset }`
 - 订阅 `editorChangeTick`（zustand）做 debounce re-parse，默认 300ms
 
-**相关文件**：`packages/editor/src/utils/extractHeadings.ts`、`src/components/editor/DocumentOutline.tsx`
+**相关文件**：`../swarmnote-editor/packages/editor-core/src/utils/extractHeadings.ts`、`src/components/editor/DocumentOutline.tsx`
 
 ## 修改编辑器包后的构建
 
-桌面端通过 pnpm workspace 直接 symlink `packages/editor/`，**不需要手动 build bundle**（和移动端的 WebView 方案不同）。但：
+主仓通过 `pnpm.overrides` 把 `@swarmnote/editor-core` link 到 `../swarmnote-editor/packages/editor-core/dist/`——所以**必须有 dist 产物**才能跑。日常开发用 watch 模式：
 
-- 修改 `packages/editor/src/**/*.ts` 后，TypeScript 检查跑 `pnpm --filter @swarmnote/editor typecheck`
-- Vite dev server 能直接 hot-reload。不需要 rebuild
+- 在 sibling 仓跑 `pnpm dev`（= `tsdown --watch`），修改 `../swarmnote-editor/packages/editor-core/src/**/*.ts` 后 dist 自动重建
+- 主仓 Vite dev server 监听 `node_modules/@swarmnote/editor-core` symlink target 的 dist 变化，HMR 自动 reload
+- TypeScript 检查在 sibling 仓跑：`(cd ../swarmnote-editor && pnpm -r typecheck)`
 
-**相关文件**：`packages/editor/package.json`、`pnpm-workspace.yaml`
+**相关文件**：`../swarmnote-editor/packages/editor-core/package.json`、`../swarmnote-editor/packages/editor-core/tsdown.config.ts`、主仓 `package.json::pnpm.overrides`
 
 ## 协作光标 (Awareness) — 生命周期与去重
 
@@ -313,7 +330,7 @@ shadcn 的 `<ContextMenu>` 已经处理了 `oncontextmenu` 拦截、Portal 位�
 
 ### `toggleHighlight` / `toggleBlockquote` 在编辑器子仓 — 跨仓提交序
 
-两个命令现位于 `packages/editor/src/editorCommands/markdown.ts`（highlight 与 strike 同 helper）和 `packages/editor/src/editorCommands/blockquote.ts`（独立文件，行级前缀切换，模式照搬 `list.ts`）。`@swarmnote/editor` 是 git submodule，更改后**必须**先 push 子仓再 bump 主仓 pointer，否则远端 submodule 指针悬空。
+两个命令现位于 `../swarmnote-editor/packages/editor-core/src/editorCommands/markdown.ts`（highlight 与 strike 同 helper）和 `../swarmnote-editor/packages/editor-core/src/editorCommands/blockquote.ts`（独立文件，行级前缀切换，模式照搬 `list.ts`）。`@swarmnote/editor-core` 是独立仓，改动走 sibling 仓 PR；本地 link 模式下主仓自动反映最新 dist，不需要主仓任何 commit。
 
 新键位：
 - `Mod-Shift-=` → `toggleHighlight`
@@ -321,7 +338,7 @@ shadcn 的 `<ContextMenu>` 已经处理了 `oncontextmenu` 拦截、Portal 位�
 
 `Mod-Shift-h` 已被 `cycleHeading` 占用，不要重用。
 
-**相关文件**：`packages/editor/src/editorCommands/markdown.ts`、`packages/editor/src/editorCommands/blockquote.ts`、`packages/editor/src/createEditor.ts::buildFormatKeymap`
+**相关文件**：`../swarmnote-editor/packages/editor-core/src/editorCommands/markdown.ts`、`../swarmnote-editor/packages/editor-core/src/editorCommands/blockquote.ts`、`../swarmnote-editor/packages/editor-core/src/createEditor.ts::buildFormatKeymap`
 
 ## Live Preview 装饰层
 
@@ -381,4 +398,4 @@ CM6 默认配置 + 暖色品牌系统会导致 selection 与 activeLine 撞色�
 - 现在的值：`activeLine: 'transparent'`、`.cm-activeLineGutter: { backgroundColor: 'transparent' }`、`selection alpha 0.30 (light) / 0.35 (dark)`
 - 取舍：用户失去"光标在哪行"的视觉锚点，依赖 caret 自身。Live Preview 模式下用户感知主要靠光标本身，可接受
 
-**相关文件**：`packages/editor/src/extensions/inlineRendering/addFormattingClasses.ts`、`packages/editor/src/extensions/inlineRendering/replaceFormatCharacters.ts`、`packages/editor/src/extensions/markdownDecorationExtension.ts`、`packages/editor/src/theme/createTheme.ts`
+**相关文件**：`../swarmnote-editor/packages/editor-core/src/extensions/inlineRendering/addFormattingClasses.ts`、`../swarmnote-editor/packages/editor-core/src/extensions/inlineRendering/replaceFormatCharacters.ts`、`../swarmnote-editor/packages/editor-core/src/extensions/markdownDecorationExtension.ts`、`../swarmnote-editor/packages/editor-core/src/theme/createTheme.ts`

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "onlyBuiltDependencies": [
       "lefthook",
       "esbuild"
-    ]
+    ],
+    "overrides": {
+      "@swarmnote/editor-core": "link:../swarmnote-editor/packages/editor-core"
+    }
   },
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.8",
@@ -27,7 +30,7 @@
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@lingui/core": "^5.9.3",
     "@lingui/react": "^5.9.3",
-    "@swarmnote/editor": "workspace:*",
+    "@swarmnote/editor-core": "*",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/react-router": "^1.168.1",
     "@tauri-apps/api": "^2.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@swarmnote/editor-core': link:../swarmnote-editor/packages/editor-core
+
 importers:
 
   .:
@@ -23,9 +26,9 @@ importers:
       '@lingui/react':
         specifier: ^5.9.3
         version: 5.9.3(@lingui/babel-plugin-lingui-macro@5.9.3(typescript@5.8.3))(react@19.2.4)
-      '@swarmnote/editor':
-        specifier: workspace:*
-        version: link:packages/editor
+      '@swarmnote/editor-core':
+        specifier: link:../swarmnote-editor/packages/editor-core
+        version: link:../swarmnote-editor/packages/editor-core
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,2 @@
 packages:
-  - "packages/*"
   - "docs"

--- a/src/components/editor/DocumentOutline.tsx
+++ b/src/components/editor/DocumentOutline.tsx
@@ -1,5 +1,5 @@
 import { Trans } from "@lingui/react/macro";
-import { extractHeadings, type HeadingItem } from "@swarmnote/editor";
+import { extractHeadings, type HeadingItem } from "@swarmnote/editor-core";
 import { ListTree } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 

--- a/src/components/editor/EditorContextMenu.tsx
+++ b/src/components/editor/EditorContextMenu.tsx
@@ -3,7 +3,7 @@ import {
   DEFAULT_SELECTION_FORMATTING,
   type EditorControl,
   type SelectionFormatting,
-} from "@swarmnote/editor";
+} from "@swarmnote/editor-core";
 import {
   Bold,
   Code,

--- a/src/components/editor/NoteEditor.tsx
+++ b/src/components/editor/NoteEditor.tsx
@@ -6,7 +6,7 @@ import {
   EditorEventType,
   type EditorSettings,
   refreshBlockImagesEffect,
-} from "@swarmnote/editor";
+} from "@swarmnote/editor-core";
 import { convertFileSrc, invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { confirm } from "@tauri-apps/plugin-dialog";
@@ -92,7 +92,7 @@ export function NoteEditor() {
 }
 
 /**
- * Inner component: mounts `@swarmnote/editor` (CM6) bound to the given
+ * Inner component: mounts `@swarmnote/editor-core` (CM6) bound to the given
  * Y.Doc via `y-codemirror.next`, wires up Tauri event bridges for flush,
  * external updates, external conflict, and asset refresh.
  *

--- a/src/components/editor/TableContextMenu.tsx
+++ b/src/components/editor/TableContextMenu.tsx
@@ -1,5 +1,5 @@
 import { useLingui } from "@lingui/react/macro";
-import type { TableAlignment, TableContextMenuActions } from "@swarmnote/editor";
+import type { TableAlignment, TableContextMenuActions } from "@swarmnote/editor-core";
 import {
   AlignCenter,
   AlignJustify,

--- a/src/stores/editorStore.ts
+++ b/src/stores/editorStore.ts
@@ -1,4 +1,4 @@
-import type { EditorControl } from "@swarmnote/editor";
+import type { EditorControl } from "@swarmnote/editor-core";
 import type { Awareness } from "y-protocols/awareness";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";


### PR DESCRIPTION
## Summary

把 SwarmNote 桌面 host 仓从"`packages/editor` git submodule + `@swarmnote/editor` workspace 包"切换到"sibling 仓 + `@swarmnote/editor-core` pnpm link"接入方式。落地 OpenSpec change `swarmnote-host-link-editor-core`（C2，前置依赖 [swarm-apps/swarmnote-editor#1](https://github.com/swarm-apps/swarmnote-editor/pull/1) 已合并）。

- **删除** `packages/editor/` git submodule + `.gitmodules` 中相应条目 + `.git/modules/packages/editor/`
- **依赖切换**：`package.json` 把 `@swarmnote/editor: workspace:*` 改为 `@swarmnote/editor-core: *`，新增 `pnpm.overrides` 把包 link 到 `../swarmnote-editor/packages/editor-core`；`pnpm-workspace.yaml` 从 `packages/*` + `docs` 收窄到只有 `docs`
- **5 个源文件 6 处 import** 从 `@swarmnote/editor` 重命名为 `@swarmnote/editor-core`（`DocumentOutline.tsx` / `EditorContextMenu.tsx` / `NoteEditor.tsx` / `TableContextMenu.tsx` / `editorStore.ts`）
- **CI** 在主仓 install 前先 `git clone` sibling 仓到 `${{ github.workspace }}/../swarmnote-editor` 并 build，主仓 `pnpm install --frozen-lockfile` 通过 `pnpm.overrides` 解析到 sibling dist
- **文档** 重写 README onboarding（三步流程：clone 主仓 → clone & build sibling → 主仓 install）、CLAUDE.md、`dev-notes/knowledge/editor.md` 中所有 submodule 措辞与 `packages/editor/src/...` 路径

## Design 偏离记录

1. **D1 / 4.4**：原计划 `pnpm link --global @swarmnote/editor-core`，但 pnpm 10.30 有个 bug——执行 `pnpm link --global @scope/name` 会自动给全局 package.json 注入 `"editor-core": "link:node_modules/@swarmnote/editor-core"` 这种循环 self-ref，触发 "Symlink path is the same as the target path" 报错。改用 `pnpm link <path>` 不加 `--global`，效果是把 `pnpm.overrides.@swarmnote/editor-core = "link:../swarmnote-editor/packages/editor-core"` 写入主仓 `package.json`。
2. **D3 / 6.1-6.2**：原计划 CI 用 `actions/checkout@v4` + `path: ../swarmnote-editor` + `NPM_CONFIG_OVERRIDES`，但 actions/checkout 校验 `path` 必须落在 `GITHUB_WORKSPACE` 内，外部路径会拒绝。改用 `git clone` 把 sibling 拉到 `${{ github.workspace }}/../swarmnote-editor`；override 已写在主仓 package.json，env 变量多余，CI 用 `pnpm install --frozen-lockfile` 直接通过。
3. **Phase 7 sanity 8.1-8.3, 8.5, 8.7**：`pnpm tauri dev` UI / Y.Doc 同步 / sibling watch HMR 都依赖真实 webview，headless 自动化覆盖不到，留给 review 期间用户手测。`pnpm build` (14.56s, ✅) + `tsc --noEmit` (✅) + 5 个编辑过的文件 `pnpm exec biome ci` (✅) 已在本机通过。本仓 `pnpm lint` 本机 113 errors 全部是预存的 Windows CRLF + `core.autocrlf=true` 问题（git index 是 LF，CI Linux runner 不会出现）。

## Verified

- 本机：editor-core sibling clone 到 `D:\workspace\swarmnote-editor` 主分支 HEAD `0f49803`（C1 monorepo init 已合并），sibling `pnpm install --frozen-lockfile && pnpm -r build` 通过，dist 含 mjs/cjs/d.mts/d.cts 完整
- 主仓 `node_modules/@swarmnote/editor-core` 是 symlink → sibling dist 路径
- 主仓 `pnpm build` 14.56s 通过，主 chunk 1.6MB 含编辑器内核符号
- `tsc --noEmit` 0 错；5 个编辑过的文件 `pnpm exec biome ci` 全绿
- 6 个 phase 提交干净分组：`chore: remove submodule` → `chore: switch dep` → `refactor: rename imports` → `ci: build sibling first` → `docs: update onboarding`

## Test plan

- [ ] CI 跑通（GitHub Actions）
- [ ] reviewer 手测 `pnpm tauri dev`：编辑器加载、可打开既有 .md、富文本预览（标题/列表/代码块/表格/admonition）、链接 tooltip、表格右键菜单、文档自动保存（1.5s debounce）、Y.Doc 双窗口同步
- [ ] reviewer 验证 sibling 仓 watch（`pnpm dev`）模式下改 editor-core 源码 → 主仓 vite HMR 自动 reload

合并后阻塞 C3（SwarmNote-RN 端切换到 editor-core，类似手术）。

OpenSpec spec/proposal/design/tasks 在主仓 `openspec/changes/swarmnote-host-link-editor-core/`（仓内 `.gitignore` 排除 `**/openspec`，所以 OpenSpec 文件本地跟踪、不进 git——遵循 SwarmNote 项目惯例）。